### PR TITLE
Add retry configurations

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,6 +45,17 @@ config:
     backend-ports:
       type: string
       description: (integrator mode) Comma-separated list of ports of the backend services.
+    retry-count:
+      type: int
+      description: Number of times to retry failed requests.
+    retry-interval:
+      type: int
+      description: Interval between retries in seconds.
+    retry-redispatch:
+      type: boolean
+      default: false
+      description: Whether to redispatch failed requests to another server.
+    
 
 charm-libs:
   - lib: haproxy.haproxy_route

--- a/docs-template/changelog.md
+++ b/docs-template/changelog.md
@@ -10,4 +10,8 @@ Each revision is versioned by the date of the revision.
 
 ### Added 
 
+- Add retry-count, retry-interval and retry-redispatch configurations
+
+### Added 
+
 - Add ingress integration support

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
                     service=f"{self.model.name}-{self.app.name}",
                     ports=integrator_information.backend_ports,
                     hosts=[str(address) for address in integrator_information.backend_addresses],
+                    retry_count=integrator_information.retry_count,
+                    retry_interval=integrator_information.retry_interval,
+                    retry_redispatch=integrator_information.retry_redispatch,
                 )
             elif mode == state.Mode.ADAPTER:
                 relation = self.model.get_relation(self._ingress.relation_name)

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,7 +60,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 retry_redispatch=charm_state.retry_redispatch,
             )
             proxied_endpoints = self._haproxy_route.get_proxied_endpoints()
-            if self._ingress:
+            if ingress_relation:
                 self._ingress.publish_url(ingress_relation, proxied_endpoints[0])
             self.unit.status = ops.ActiveStatus()
         except state.InvalidStateError as ex:

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,7 +62,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 subdomains=charm_state.subdomains,
             )
             proxied_endpoints = self._haproxy_route.get_proxied_endpoints()
-            if ingress_relation:
+            if ingress_relation and proxied_endpoints:
                 self._ingress.publish_url(ingress_relation, proxied_endpoints[0])
             self.unit.status = ops.ActiveStatus()
         except state.InvalidStateError as ex:

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,8 +46,8 @@ class IngressConfiguratorCharm(ops.CharmBase):
             if not self._haproxy_route.relation:
                 self.unit.status = ops.BlockedStatus("Missing haproxy-route relation.")
                 return
-            integrator_information = state.IntegratorInformation.from_charm(self)
             mode = state.get_mode(self, self.model.get_relation(self._ingress.relation_name))
+            integrator_information = state.IntegratorInformation.from_charm(self)
             if mode == state.Mode.INTEGRATOR:
                 self._haproxy_route.provide_haproxy_route_requirements(
                     service=f"{self.model.name}-{self.app.name}",

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,10 +63,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
             if self._ingress:
                 self._ingress.publish_url(ingress_relation, proxied_endpoints[0])
             self.unit.status = ops.ActiveStatus()
-        except state.UndefinedModeError:
-            logger.exception("Undefined operating mode")
-            self.unit.status = ops.BlockedStatus("Operating mode is undefined.")
-        except state.InvalidIntegratorConfigError as ex:
+        except state.InvalidStateError as ex:
             logger.exception("Invalid configuration")
             self.unit.status = ops.BlockedStatus(str(ex))
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,9 +46,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
             if not self._haproxy_route.relation:
                 self.unit.status = ops.BlockedStatus("Missing haproxy-route relation.")
                 return
+            integrator_information = state.IntegratorInformation.from_charm(self)
             mode = state.get_mode(self, self.model.get_relation(self._ingress.relation_name))
             if mode == state.Mode.INTEGRATOR:
-                integrator_information = state.IntegratorInformation.from_charm(self)
                 self._haproxy_route.provide_haproxy_route_requirements(
                     service=f"{self.model.name}-{self.app.name}",
                     ports=integrator_information.backend_ports,
@@ -64,6 +64,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
                     service=f"{data.app.model}-{data.app.name}",
                     ports=[data.app.port],
                     hosts=[str(unit.ip) for unit in data.units],
+                    retry_count=integrator_information.retry_count,
+                    retry_interval=integrator_information.retry_interval,
+                    retry_redispatch=integrator_information.retry_redispatch,
                 )
                 proxied_endpoints = self._haproxy_route.get_proxied_endpoints()
                 if proxied_endpoints:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -42,24 +42,6 @@ def test_config_changed_invalid_mode(monkeypatch: pytest.MonkeyPatch, context):
     assert out.unit_status == ops.testing.BlockedStatus("Operating mode is undefined.")
 
 
-def test_config_changed_integrator_missing_config(monkeypatch: pytest.MonkeyPatch, context):
-    """
-    arrange: prepare some state with haproxy-route relation and no configuration.
-    act: trigger a config changed event.
-    assert: status is blocked.
-    """
-    monkeypatch.setattr(state, "get_mode", MagicMock(return_value=state.Mode.INTEGRATOR))
-    charm_state = ops.testing.State(
-        relations=[ops.testing.Relation("haproxy-route")],
-    )
-
-    out = context.run(context.on.config_changed(), charm_state)
-
-    assert out.unit_status == ops.testing.BlockedStatus(
-        "Missing configuration for integrator mode: backend-addresses backend-ports"
-    )
-
-
 def test_config_changed_integrator_invalid_addresses(monkeypatch: pytest.MonkeyPatch, context):
     """
     arrange: prepare some state with invalid backend-addresses.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -30,7 +30,7 @@ def test_config_changed_invalid_state(monkeypatch: pytest.MonkeyPatch, context):
     """
     arrange: prepare some state with invalid backend-addresses.
     act: trigger a config changed event.
-    assert: status is bllocked.
+    assert: status is blocked.
     """
     monkeypatch.setattr(state.State, "from_charm", MagicMock(side_effect=state.InvalidStateError))
     charm_state = ops.testing.State(
@@ -41,3 +41,19 @@ def test_config_changed_invalid_state(monkeypatch: pytest.MonkeyPatch, context):
     out = context.run(context.on.config_changed(), charm_state)
 
     assert out.unit_status == ops.testing.BlockedStatus()
+
+
+def test_config_changed_integrator(context):
+    """
+    arrange: prepare some valid state for an integrator.
+    act: trigger a config changed event.
+    assert: status is active.
+    """
+    charm_state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1,10.0.0.2", "backend-ports": "8080,8081"},
+        relations=[ops.testing.Relation("haproxy-route")],
+    )
+
+    out = context.run(context.on.config_changed(), charm_state)
+
+    assert out.unit_status == ops.testing.ActiveStatus()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -26,29 +26,13 @@ def test_config_changed_no_haproxy_route_relation(context):
     assert out.unit_status == ops.testing.BlockedStatus("Missing haproxy-route relation.")
 
 
-def test_config_changed_invalid_mode(monkeypatch: pytest.MonkeyPatch, context):
-    """
-    arrange: prepare some state and patch invalid mode.
-    act: trigger a config changed event.
-    assert: status is blocked.
-    """
-    monkeypatch.setattr(state, "get_mode", MagicMock(side_effect=state.UndefinedModeError))
-    charm_state = ops.testing.State(
-        relations=[ops.testing.Relation("haproxy-route")],
-    )
-
-    out = context.run(context.on.config_changed(), charm_state)
-
-    assert out.unit_status == ops.testing.BlockedStatus("Operating mode is undefined.")
-
-
-def test_config_changed_integrator_invalid_addresses(monkeypatch: pytest.MonkeyPatch, context):
+def test_config_changed_invalid_state(monkeypatch: pytest.MonkeyPatch, context):
     """
     arrange: prepare some state with invalid backend-addresses.
     act: trigger a config changed event.
     assert: status is bllocked.
     """
-    monkeypatch.setattr(state, "get_mode", MagicMock(return_value=state.Mode.INTEGRATOR))
+    monkeypatch.setattr(state.State, "from_charm", MagicMock(side_effect=state.InvalidStateError))
     charm_state = ops.testing.State(
         config={"backend-addresses": "10.0.0.1,invalid", "backend-ports": "8080,8081"},
         relations=[ops.testing.Relation("haproxy-route")],
@@ -56,25 +40,4 @@ def test_config_changed_integrator_invalid_addresses(monkeypatch: pytest.MonkeyP
 
     out = context.run(context.on.config_changed(), charm_state)
 
-    assert out.unit_status == ops.testing.BlockedStatus(
-        "Invalid integrator configuration: backend_addresses-1"
-    )
-
-
-def test_config_changed_integrator_invalid_ports(monkeypatch: pytest.MonkeyPatch, context):
-    """
-    arrange: prepare some state with invalid ports.
-    act: trigger a config changed event with invalid port configuration.
-    assert: status is blocked with the correct message.
-    """
-    monkeypatch.setattr(state, "get_mode", MagicMock(return_value=state.Mode.INTEGRATOR))
-    charm_state = ops.testing.State(
-        config={"backend-addresses": "10.0.0.1,10.0.0.2", "backend-ports": "99999"},
-        relations=[ops.testing.Relation("haproxy-route")],
-    )
-
-    out = context.run(context.on.config_changed(), charm_state)
-
-    assert out.unit_status == ops.testing.BlockedStatus(
-        "Invalid integrator configuration: backend_ports-0"
-    )
+    assert out.unit_status == ops.testing.BlockedStatus()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -63,6 +63,9 @@ def test_get_integrator_information():
     charm.config = {
         "backend-addresses": "127.0.0.1,127.0.0.2",
         "backend-ports": "8080,8081",
+        "retry-count": 1,
+        "retry-interval": 10,
+        "retry-redispatch": True,
     }
     info = state.IntegratorInformation.from_charm(charm)
     assert [str(address) for address in info.backend_addresses] == charm.config.get(
@@ -71,6 +74,9 @@ def test_get_integrator_information():
     assert [str(port) for port in info.backend_ports] == charm.config.get("backend-ports").split(
         ","
     )
+    assert info.retry_count == charm.config.get("retry-count")
+    assert info.retry_interval == charm.config.get("retry-interval")
+    assert info.retry_redispatch == charm.config.get("retry-redispatch")
 
 
 def test_get_integrator_information_no_address():
@@ -96,6 +102,34 @@ def test_get_integrator_information_no_port():
     charm = Mock(CharmBase)
     charm.config = {
         "backend-addresses": "127.0.0.1,127.0.0.2",
+    }
+    with pytest.raises(state.InvalidIntegratorConfigError):
+        state.IntegratorInformation.from_charm(charm)
+
+
+def test_get_integrator_information_invalid_retry_count():
+    """
+    arrange: mock a charm with backend address and without retry-count configuration
+    act: instantiate a IntegratorInformation
+    assert: a InvalidIntegratorConfigError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "retry-count": -1,
+    }
+    with pytest.raises(state.InvalidIntegratorConfigError):
+        state.IntegratorInformation.from_charm(charm)
+
+
+def test_get_integrator_information_invalid_retry_interval():
+    """
+    arrange: mock a charm with backend address and without retry-interval configuration
+    act: instantiate a IntegratorInformation
+    assert: a InvalidIntegratorConfigError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "retry-interval": -1,
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
         state.IntegratorInformation.from_charm(charm)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -56,7 +56,7 @@ def test_get_mode_invalid():
 def test_integrator_information_from_charm():
     """
     arrange: mock a charm with backend configuration
-    act: instantiate a IntegratorInformation
+    act: instantiate a State
     assert: the data matches the charm configuration
     """
     charm = Mock(CharmBase)
@@ -67,7 +67,7 @@ def test_integrator_information_from_charm():
         "retry-interval": 10,
         "retry-redispatch": True,
     }
-    info = state.IntegratorInformation.from_charm(charm)
+    info = state.State.from_charm(charm)
     assert [str(address) for address in info.backend_addresses] == charm.config.get(
         "backend-addresses"
     ).split(",")
@@ -82,7 +82,7 @@ def test_integrator_information_from_charm():
 def test_get_integrator_information_invalid_address():
     """
     arrange: mock a charm with backend port and without address configuration
-    act: instantiate a IntegratorInformation
+    act: instantiate a State
     assert: a InvalidIntegratorConfigError is raised
     """
     charm = Mock(CharmBase)
@@ -91,13 +91,13 @@ def test_get_integrator_information_invalid_address():
         "backend-ports": "8080",
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
-        state.IntegratorInformation.from_charm(charm)
+        state.State.from_charm(charm)
 
 
 def test_get_integrator_information_invalid_port():
     """
     arrange: mock a charm with backend address and without port configuration
-    act: instantiate a IntegratorInformation
+    act: instantiate a State
     assert: a InvalidIntegratorConfigError is raised
     """
     charm = Mock(CharmBase)
@@ -106,13 +106,13 @@ def test_get_integrator_information_invalid_port():
         "backend-ports": "99999",
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
-        state.IntegratorInformation.from_charm(charm)
+        state.State.from_charm(charm)
 
 
 def test_get_integrator_information_invalid_retry_count():
     """
     arrange: mock a charm with backend address and without retry-count configuration
-    act: instantiate a IntegratorInformation
+    act: instantiate a State
     assert: a InvalidIntegratorConfigError is raised
     """
     charm = Mock(CharmBase)
@@ -120,13 +120,13 @@ def test_get_integrator_information_invalid_retry_count():
         "retry-count": -1,
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
-        state.IntegratorInformation.from_charm(charm)
+        state.State.from_charm(charm)
 
 
 def test_get_integrator_information_invalid_retry_interval():
     """
     arrange: mock a charm with backend address and without retry-interval configuration
-    act: instantiate a IntegratorInformation
+    act: instantiate a State
     assert: a InvalidIntegratorConfigError is raised
     """
     charm = Mock(CharmBase)
@@ -134,4 +134,4 @@ def test_get_integrator_information_invalid_retry_interval():
         "retry-interval": -1,
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
-        state.IntegratorInformation.from_charm(charm)
+        state.State.from_charm(charm)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -53,7 +53,7 @@ def test_get_mode_invalid():
         state.get_mode(charm, relation)
 
 
-def test_get_integrator_information():
+def test_integrator_information_from_charm():
     """
     arrange: mock a charm with backend configuration
     act: instantiate a IntegratorInformation

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -33,10 +33,10 @@ def test_adapter_state_from_charm():
         units=[IngressRequirerUnitData(host="sample.host", ip="127.0.0.1")],
     )
     charm_state = state.State.from_charm(charm, ingress_relation_data)
-    assert [str(address) for address in charm_state.backend_addresses] == list(
+    assert [str(address) for address in charm_state.backend_addresses] == [
         ingress_relation_data.units[0].ip
-    )
-    assert list(port for port in charm_state.backend_ports) == list(ingress_relation_data.app.port)
+    ]
+    assert charm_state.backend_ports == [ingress_relation_data.app.port]
     assert charm_state.retry_count == charm.config.get("retry-count")
     assert charm_state.retry_interval == charm.config.get("retry-interval")
     assert charm_state.retry_redispatch == charm.config.get("retry-redispatch")

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -79,7 +79,7 @@ def test_get_integrator_information():
     assert info.retry_redispatch == charm.config.get("retry-redispatch")
 
 
-def test_get_integrator_information_no_address():
+def test_get_integrator_information_invalid_address():
     """
     arrange: mock a charm with backend port and without address configuration
     act: instantiate a IntegratorInformation
@@ -87,13 +87,14 @@ def test_get_integrator_information_no_address():
     """
     charm = Mock(CharmBase)
     charm.config = {
-        "backend-ports": "8080,8081",
+        "backend-addresses": "invalid",
+        "backend-ports": "8080",
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
         state.IntegratorInformation.from_charm(charm)
 
 
-def test_get_integrator_information_no_port():
+def test_get_integrator_information_invalid_port():
     """
     arrange: mock a charm with backend address and without port configuration
     act: instantiate a IntegratorInformation
@@ -102,6 +103,7 @@ def test_get_integrator_information_no_port():
     charm = Mock(CharmBase)
     charm.config = {
         "backend-addresses": "127.0.0.1,127.0.0.2",
+        "backend-ports": "99999",
     }
     with pytest.raises(state.InvalidIntegratorConfigError):
         state.IntegratorInformation.from_charm(charm)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
* Add retry-count, retry-interval and retry-redispatch configurations

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
