### PR TITLE
ISD-3855 replace subdomains with hostname and additional-hostnames, update tests.

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -82,9 +82,12 @@ config:
     timeout-queue:
       type: int
       description: Timeout for requests waiting in queue in seconds.
-    subdomains:
+    hostname:
       type: string
-      description: Comma-separated list of subdomains to route to the service.
+      description: The hostname to route to the service.
+    additional-hostnames:
+      type: string
+      description: Comma-separated list of additional_hostnames to route to the service. Will be ignored if hostname is not set.
 
 charm-libs:
   - lib: haproxy.haproxy_route

--- a/src/charm.py
+++ b/src/charm.py
@@ -67,7 +67,8 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 "connect_timeout": charm_state.timeout.connect,
                 "queue_timeout": charm_state.timeout.queue,
                 "service": charm_state.service,
-                "subdomains": charm_state.subdomains,
+                "hostname": charm_state.hostname,
+                "additional_hostnames": charm_state.additional_hostnames,
             }
             not_none_params = {k: v for k, v in params.items() if v is not None}
             self._haproxy_route.provide_haproxy_route_requirements(**not_none_params)

--- a/src/state.py
+++ b/src/state.py
@@ -4,7 +4,7 @@
 """ingress-configurator-operator integrator information."""
 
 import logging
-from typing import Annotated, cast
+from typing import Annotated, Optional, cast
 
 import ops
 from annotated_types import Len
@@ -176,6 +176,7 @@ class Retry:
         return cls(count=count, interval=interval, redispatch=redispatch)
 
 
+# pylint: disable=too-many-instance-attributes,too-many-locals
 @dataclass(frozen=True)
 class State:
     """Charm state that contains the configuration.
@@ -188,7 +189,8 @@ class State:
         timeout: The timeout configuration.
         service: The service name.
         paths: List of URL paths to route to the service.
-        subdomains: List of subdomains to route to the service.
+        hostname: The hostname to route to the service.
+        additional_hostnames: List of additional hostnames to route to the service.
     """
 
     _backend_state: BackendState
@@ -197,8 +199,11 @@ class State:
     timeout: Timeout
     service: str = Field(..., min_length=1)
     paths: list[Annotated[str, BeforeValidator(value_has_valid_characters)]] = Field(default=[])
-    subdomains: list[Annotated[str, BeforeValidator(value_has_valid_characters)]] = Field(
-        default=[]
+    hostname: Optional[Annotated[str, BeforeValidator(value_has_valid_characters)]] = Field(
+        default=None
+    )
+    additional_hostnames: list[Annotated[str, BeforeValidator(value_has_valid_characters)]] = (
+        Field(default=[])
     )
 
     @property
@@ -247,9 +252,10 @@ class State:
             if charm.config.get("paths")
             else []
         )
-        subdomains = (
-            cast(str, charm.config.get("subdomains")).split(CHARM_CONFIG_DELIMITER)
-            if charm.config.get("subdomains")
+        hostname = cast(Optional[str], charm.config.get("hostname"))
+        additional_hostnames = (
+            cast(str, charm.config.get("additional-hostnames")).split(CHARM_CONFIG_DELIMITER)
+            if charm.config.get("additional-hostnames")
             else []
         )
         try:
@@ -267,7 +273,8 @@ class State:
                 retry=Retry.from_charm(charm),
                 timeout=Timeout.from_charm(charm),
                 service=f"{charm.model.name}-{charm.app.name}",
-                subdomains=subdomains,
+                hostname=hostname,
+                additional_hostnames=additional_hostnames,
             )
         except ValidationError as exc:
             logger.error(str(exc))

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -5,7 +5,6 @@
 
 from urllib.parse import urlparse
 
-from requests import Response, Session
 from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_POOLSIZE, DEFAULT_RETRIES, HTTPAdapter
 
 
@@ -68,20 +67,3 @@ class DNSResolverHTTPSAdapter(HTTPAdapter):
                 connection_pool_kwargs.pop("assert_hostname", None)
 
         return super().send(request, stream, timeout, verify, cert, proxies)
-
-
-def haproxy_request(session: Session, url: str) -> Response:
-    """Make a request to the HAProxy service.
-
-    Args:
-        session: Requests session with custom DNS resolution.
-        url: URL to request from the HAProxy service.
-
-    Returns:
-        Response: HTTP response from the HAProxy service.
-    """
-    return session.get(
-        url,
-        timeout=30,
-        verify=False,  # nosec - calling charm ingress URL
-    )

--- a/tests/integration/test_adapter.py
+++ b/tests/integration/test_adapter.py
@@ -8,8 +8,7 @@ from typing import Callable
 import jubilant
 from requests import Session
 
-from .conftest import MOCK_HAPROXY_HOSTNAME
-from .helper import haproxy_request
+from .conftest import MOCK_HAPROXY_HOSTNAME, get_unit_addresses
 
 
 def test_adapter_end_to_end_routing(
@@ -34,6 +33,8 @@ def test_adapter_end_to_end_routing(
         error=jubilant.any_error,
     )
 
-    session = http_session()
-    response = haproxy_request(session, f"https://{MOCK_HAPROXY_HOSTNAME}")
+    session = http_session(
+        dns_entries=[(MOCK_HAPROXY_HOSTNAME, str(get_unit_addresses(juju, haproxy)[0]))]
+    )
+    response = session.get(f"https://{MOCK_HAPROXY_HOSTNAME}", verify=False, timeout=30)
     assert "Apache2 Default Page" in response.text

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -36,7 +36,8 @@ def test_adapter_state_from_charm():
         "timeout-connect": 12,
         "timeout-queue": 13,
         "paths": "/api/v1,/api/v2",
-        "subdomains": "api",
+        "hostname": "api.example.com",
+        "additional-hostnames": "api2.example.com,api3.example.com",
     }
     ingress_relation_data = IngressRequirerData(
         app=IngressRequirerAppData(model="model", name="name", port=8080),
@@ -60,7 +61,8 @@ def test_adapter_state_from_charm():
     assert charm_state.timeout.connect == charm.config.get("timeout-connect")
     assert charm_state.timeout.queue == charm.config.get("timeout-queue")
     assert charm_state.paths == charm.config.get("paths").split(",")
-    assert charm_state.subdomains == charm.config.get("subdomains").split(",")
+    assert charm_state.hostname == charm.config.get("hostname")
+    assert charm_state.additional_hostnames == charm.config.get("additional-hostnames").split(",")
 
 
 def test_integrator_state_from_charm():
@@ -307,9 +309,9 @@ def test_state_from_charm_invalid_timeout_queue():
         state.State.from_charm(charm, None)
 
 
-def test_state_from_charm_invalid_subdomains():
+def test_state_from_charm_invalid_hostname():
     """
-    arrange: mock a charm with backend addresses, ports configuration and invalid subdomains
+    arrange: mock a charm with backend addresses, ports configuration and invalid hostname
     act: instantiate a State
     assert: a InvalidStateError is raised
     """
@@ -317,7 +319,7 @@ def test_state_from_charm_invalid_subdomains():
     charm.config = {
         "backend-addresses": "127.0.0.1,127.0.0.2",
         "backend-ports": "8080,8081",
-        "subdomains": "invalid$subdomains",
+        "hostname": "invalid$hostname",
     }
     with pytest.raises(state.InvalidStateError):
         state.State.from_charm(charm, None)


### PR DESCRIPTION
Applicable spec: ISD-229 ( internal )

replaces the deprecated `subdomains` charm config and replace it with `hostname` and `additional-hostnames` to enable support for multidomain

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
