### PR TITLE
Require interval, fall and rise health checks to either be all set or none

### DIFF
--- a/docs-template/changelog.md
+++ b/docs-template/changelog.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-07-21
+
+### Changed
+
+ - Require interval, fall and rise health checks to either be all set or none
+
+
 ## 2025-07-14
 
 ### Added 

--- a/src/state.py
+++ b/src/state.py
@@ -95,7 +95,8 @@ class HealthCheck:
         all_or_none_health_checks_set = bool(interval) == bool(rise) == bool(fall)
         if not all_or_none_health_checks_set:
             raise InvalidStateError(
-                "Health check configuration is incomplete: interval, rise, and fall must all be set if any one of them is specified."
+                "Health check configuration is incomplete: interval, rise, and fall "
+                "must all be set if any one of them is specified."
             )
         return cls(interval=interval, rise=rise, fall=fall, path=path, port=port)
 

--- a/src/state.py
+++ b/src/state.py
@@ -92,8 +92,8 @@ class HealthCheck:
             if charm.config.get("health-check-port") is not None
             else None
         )
-        all_or_none_heatth_checks_set = bool(interval) == bool(rise) == bool(fall)
-        if not all_or_none_heatth_checks_set:
+        all_or_none_health_checks_set = bool(interval) == bool(rise) == bool(fall)
+        if not all_or_none_health_checks_set:
             raise InvalidStateError(
                 "Interval, raise and fall configurations need all to be defined if one is set."
             )

--- a/src/state.py
+++ b/src/state.py
@@ -95,7 +95,7 @@ class HealthCheck:
         all_or_none_health_checks_set = bool(interval) == bool(rise) == bool(fall)
         if not all_or_none_health_checks_set:
             raise InvalidStateError(
-                "Interval, raise and fall configurations need all to be defined if one is set."
+                "Health check configuration is incomplete: interval, rise, and fall must all be set if any one of them is specified."
             )
         return cls(interval=interval, rise=rise, fall=fall, path=path, port=port)
 

--- a/src/state.py
+++ b/src/state.py
@@ -63,6 +63,9 @@ class HealthCheck:
 
         Returns:
             HealthCheck: instance of the health check component.
+
+        Raises:
+            InvalidStateError: when the configuration is invalid.
         """
         interval = (
             cast(int, charm.config.get("health-check-interval"))
@@ -89,6 +92,11 @@ class HealthCheck:
             if charm.config.get("health-check-port") is not None
             else None
         )
+        all_or_none_heatth_checks_set = bool(interval) == bool(rise) == bool(fall)
+        if not all_or_none_heatth_checks_set:
+            raise InvalidStateError(
+                "Interval, raise and fall configurations need all to be defined if one is set."
+            )
         return cls(interval=interval, rise=rise, fall=fall, path=path, port=port)
 
 

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -229,6 +229,57 @@ def test_state_from_charm_invalid_check_fall():
         state.State.from_charm(charm, None)
 
 
+def test_state_from_charm_invalid_missing_check_interval():
+    """
+    arrange: mock a charm with backend address and unset health-check-interval configuration
+    act: instantiate a State
+    assert: a InvalidStateError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "backend-addresses": "127.0.0.1,127.0.0.2",
+        "backend-ports": "8080,8081",
+        "health-check-rise": 3,
+        "health-check-fall": 4,
+    }
+    with pytest.raises(state.InvalidStateError):
+        state.State.from_charm(charm, None)
+
+
+def test_state_from_charm_invalid_missing_check_rise():
+    """
+    arrange: mock a charm with backend address and unset health-check-rise configuration
+    act: instantiate a State
+    assert: a InvalidStateError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "backend-addresses": "127.0.0.1,127.0.0.2",
+        "backend-ports": "8080,8081",
+        "health-check-interval": 20,
+        "health-check-fall": 4,
+    }
+    with pytest.raises(state.InvalidStateError):
+        state.State.from_charm(charm, None)
+
+
+def test_state_from_charm_invalid_missing_check_fall():
+    """
+    arrange: mock a charm with backend address and unset health-check-fall configuration
+    act: instantiate a State
+    assert: a InvalidStateError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "backend-addresses": "127.0.0.1,127.0.0.2",
+        "backend-ports": "8080,8081",
+        "health-check-interval": 20,
+        "health-check-rise": 3,
+    }
+    with pytest.raises(state.InvalidStateError):
+        state.State.from_charm(charm, None)
+
+
 def test_state_from_charm_invalid_retry_count():
     """
     arrange: mock a charm with backend address and invalid retry-count configuration


### PR DESCRIPTION
### Overview

<!-- A high level overview of the change -->
Require interval, fall and rise health checks to either be all set or none. This is aligned with the upcoming changes in the haproxy route interface

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
