### PR TITLE
ISD-3918 add backend-protocol config option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -45,6 +45,9 @@ config:
     backend-ports:
       type: string
       description: (integrator mode) Comma-separated list of ports of the backend services.
+    backend-protocol:
+      type: string
+      description: The protocol that the backend service speaks. "http" (default) or "https".
     health-check-interval:
       type: int
       description: Interval between health checks in seconds.

--- a/docs-template/changelog.md
+++ b/docs-template/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2025-08-01
+
+### Changed
+
+ - Add backend-protocol configuration option.
+
 ## 2025-07-21
 
 ### Changed

--- a/src/charm.py
+++ b/src/charm.py
@@ -60,6 +60,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 "check_port": charm_state.health_check.port,
                 "paths": charm_state.paths,
                 "ports": charm_state.backend_ports,
+                "protocol": charm_state.backend_protocol,
                 "retry_count": charm_state.retry.count,
                 "retry_interval": charm_state.retry.interval,
                 "retry_redispatch": charm_state.retry.redispatch,

--- a/src/state.py
+++ b/src/state.py
@@ -279,8 +279,8 @@ class State:
                 else []
             )
 
-            config_backend = config_backend_addresses or config_backend_ports
-            ingress_backend = ingress_backend_addresses or ingress_backend_ports
+            config_backend = bool(config_backend_addresses or config_backend_ports)
+            ingress_backend = bool(ingress_backend_addresses or ingress_backend_ports)
             # Only backend configuration from a single origin is supported
             if config_backend == ingress_backend:
                 raise InvalidStateError("No valid mode detected.")

--- a/src/state.py
+++ b/src/state.py
@@ -4,7 +4,7 @@
 """ingress-configurator-operator integrator information."""
 
 import logging
-from typing import Annotated, Optional, cast
+from typing import Annotated, Literal, Optional, cast
 
 import ops
 from annotated_types import Len
@@ -30,10 +30,12 @@ class BackendState:
     Attributes:
         backend_addresses: Configured list of backend ip addresses.
         backend_ports: Configured list of backend ports.
+        backend_protocol: The configured protocol for the backend.
     """
 
     backend_addresses: Annotated[list[IPvAnyAddress], Len(min_length=1)]
     backend_ports: Annotated[list[Annotated[int, Field(gt=0, le=65535)]], Len(min_length=1)]
+    backend_protocol: Literal["http", "https"]
 
 
 @dataclass(frozen=True)
@@ -201,6 +203,7 @@ class State:
     Attributes:
         backend_addresses: Configured list of backend ip addresses.
         backend_ports: Configured list of backend ports.
+        backend_protocol: The configured protocol for the backend.
         health_check: Health check configuration.
         retry: Retry configuration.
         timeout: The timeout configuration.
@@ -233,6 +236,11 @@ class State:
         """List of backend ports."""
         return self._backend_state.backend_ports
 
+    @property
+    def backend_protocol(self) -> Literal["http", "https"]:
+        """The backend protocol."""
+        return self._backend_state.backend_protocol
+
     @classmethod
     def from_charm(cls, charm: ops.CharmBase, ingress_data: IngressRequirerData | None) -> "State":
         """Create an State class from a charm instance.
@@ -261,6 +269,11 @@ class State:
                 if charm.config.get("backend-ports")
                 else []
             )
+            # The value will be validated by the BackendState constructor
+            backend_protocol = cast(
+                Literal["http", "https"],
+                (charm.config.get("backend-protocol") or "http"),
+            )
             ingress_backend_ports = [ingress_data.app.port] if ingress_data else []
             ingress_backend_addresses = (
                 [cast(IPvAnyAddress, unit.ip) for unit in ingress_data.units]
@@ -287,7 +300,7 @@ class State:
             backend_addresses = config_backend_addresses or ingress_backend_addresses
             backend_ports = config_backend_ports or ingress_backend_ports
             return cls(
-                _backend_state=BackendState(backend_addresses, backend_ports),
+                _backend_state=BackendState(backend_addresses, backend_ports, backend_protocol),
                 paths=paths,
                 health_check=HealthCheck.from_charm(charm),
                 retry=Retry.from_charm(charm),

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -49,6 +49,7 @@ def test_adapter_state_from_charm():
         ingress_relation_data.units[0].ip
     ]
     assert charm_state.backend_ports == [ingress_relation_data.app.port]
+    assert charm_state.backend_protocol == "http"
     assert charm_state.health_check.interval == charm.config.get("health-check-interval")
     assert charm_state.health_check.rise == charm.config.get("health-check-rise")
     assert charm_state.health_check.fall == charm.config.get("health-check-fall")
@@ -86,6 +87,7 @@ def test_integrator_state_from_charm():
     assert [str(port) for port in charm_state.backend_ports] == charm.config.get(
         "backend-ports"
     ).split(",")
+    assert charm_state.backend_protocol == "http"
     assert charm_state.retry.count == charm.config.get("retry-count")
     assert charm_state.retry.interval == charm.config.get("retry-interval")
     assert charm_state.retry.redispatch == charm.config.get("retry-redispatch")
@@ -144,6 +146,18 @@ def test_state_from_charm_invalid_port():
     charm.config = {
         "backend-addresses": "127.0.0.1,127.0.0.2",
         "backend-ports": "99999",
+    }
+    with pytest.raises(state.InvalidStateError):
+        state.State.from_charm(charm, None)
+
+
+def test_state_from_charm_invalid_protocol():
+    """Check that backend-protocol config field is validated."""
+    charm = Mock(CharmBase)
+    charm.config = {
+        "backend-addresses": "127.0.0.1,127.0.0.2",
+        "backend-ports": "80",
+        "backend-protocol": "gopher",
     }
     with pytest.raises(state.InvalidStateError):
         state.State.from_charm(charm, None)


### PR DESCRIPTION
Applicable spec: https://docs.google.com/document/d/1NbjHuynMMsYwGMJaq8N9M70dyZgbxqBElz2aYocp5EM/edit?tab=t.0

### Overview

Adds the `backend-protocol` configuration option that's propagated to HAProxy over `haproxy-route` relation.

The setting is applied in both adapter and integrator modes. This has to be as long as the `ingress` relation doesn't support protocol of its own.

### Rationale

Being able to connect HTTPS upstream servers to HAProxy

### Juju Events Changes

none

### Module Changes

state and charm

### Library Changes

Bumps up the `haproxy_route` charm lib to latest, as that contains the protocol field.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
