### PR TITLE
add charm config for load balancing, add tests

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -87,8 +87,24 @@ config:
       description: The hostname to route to the backend service.
     additional-hostnames:
       type: string
-      description: Comma-separated list of additional_hostnames to route to the service. Will be ignored if hostname is not set.
-
+      description: |
+        Comma-separated list of additional_hostnames to route to the service.
+        Will be ignored if hostname is not set.
+    load-balancing-algorithm:
+      type: string
+      description: |
+        Algorithm to use to load balance incoming requests. 
+        Can be leastconn, roundrobin, cookie or source
+      default: leastconn
+    load-balancing-cookie:
+      type: string
+      description: Only applies with algorithm is "cookie". Cookie name to use for load balancing.
+    load-balancing-consistent-hashing:
+      type: boolean
+      description: |
+        Only applies when the `algorithm` is "source" or "cookie".
+        Use consistent hashing to avoid redirection when servers are added/removed.
+      default: false
 charm-libs:
   - lib: haproxy.haproxy_route
     version: "1"

--- a/lib/charms/haproxy/v1/haproxy_route.py
+++ b/lib/charms/haproxy/v1/haproxy_route.py
@@ -148,7 +148,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 logger = logging.getLogger(__name__)
 HAPROXY_ROUTE_RELATION_NAME = "haproxy-route"
@@ -383,6 +383,8 @@ class LoadBalancingConfiguration(BaseModel):
     Attributes:
         algorithm: Algorithm to use for load balancing.
         cookie: Cookie name to use when algorithm is set to cookie.
+        consistent_hashing: Use consistent hashing to avoid redirection
+            when servers are added/removed.
     """
 
     algorithm: LoadBalancingAlgorithm = Field(
@@ -393,6 +395,38 @@ class LoadBalancingConfiguration(BaseModel):
         description="Only used when algorithm is COOKIE. Define the cookie to load balance on.",
         default=None,
     )
+    # Note: Later when the generic LoadBalancingAlgorithm.HASH is implemented this attribute
+    # will also apply under that mode.
+    consistent_hashing: bool = Field(
+        description=(
+            "Only used when the `algorithm` is SRCIP or COOKIE. "
+            "Use consistent hashing to avoid redirection when servers are added/removed. "
+            "Default is False as it usually does not give a balanced distribution."
+        ),
+        default=False,
+    )
+
+    @model_validator(mode="after")
+    def validate_attributes(self) -> Self:
+        """Check that algorithm-specific configs are only set with their respective algorithm.
+
+        Raises:
+            ValueError: When validation fails in one of these cases:
+                1. self.cookie is not None when self.algorithm != COOKIE
+                2. self.consistent_hashing is True when algorithm is neither COOKIE nor SRCIP
+
+        Returns:
+            The validated model.
+        """
+        if self.cookie is not None and self.algorithm != LoadBalancingAlgorithm.COOKIE:
+            raise ValueError("cookie only applies when algorithm is COOKIE.")
+
+        if self.consistent_hashing and self.algorithm not in [
+            LoadBalancingAlgorithm.COOKIE,
+            LoadBalancingAlgorithm.SRCIP,
+        ]:
+            raise ValueError("Consistent hashing only applies when algorithm is COOKIE or SRCIP.")
+        return self
 
 
 class BandwidthLimit(BaseModel):
@@ -890,6 +924,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -926,6 +961,7 @@ class HaproxyRouteRequirer(Object):
                 and rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -965,6 +1001,7 @@ class HaproxyRouteRequirer(Object):
             header_rewrite_expressions,
             load_balancing_algorithm,
             load_balancing_cookie,
+            load_balancing_consistent_hashing,
             rate_limit_connections_per_minute,
             rate_limit_policy,
             upload_limit,
@@ -1018,6 +1055,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -1052,6 +1090,7 @@ class HaproxyRouteRequirer(Object):
                 and rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -1084,6 +1123,7 @@ class HaproxyRouteRequirer(Object):
             header_rewrite_expressions,
             load_balancing_algorithm,
             load_balancing_cookie,
+            load_balancing_consistent_hashing,
             rate_limit_connections_per_minute,
             rate_limit_policy,
             upload_limit,
@@ -1118,6 +1158,7 @@ class HaproxyRouteRequirer(Object):
         header_rewrite_expressions: Optional[list[tuple[str, str]]] = None,
         load_balancing_algorithm: LoadBalancingAlgorithm = LoadBalancingAlgorithm.LEASTCONN,
         load_balancing_cookie: Optional[str] = None,
+        load_balancing_consistent_hashing: bool = False,
         rate_limit_connections_per_minute: Optional[int] = None,
         rate_limit_policy: RateLimitPolicy = RateLimitPolicy.DENY,
         upload_limit: Optional[int] = None,
@@ -1151,6 +1192,7 @@ class HaproxyRouteRequirer(Object):
                 rewrite expression.
             load_balancing_algorithm: Algorithm to use for load balancing.
             load_balancing_cookie: Cookie name to use when algorithm is set to cookie.
+            load_balancing_consistent_hashing: Whether to use consistent hashing.
             rate_limit_connections_per_minute: Maximum connections allowed per minute.
             rate_limit_policy: Policy to apply when rate limit is reached.
             upload_limit: Maximum upload bandwidth in bytes per second.
@@ -1195,6 +1237,7 @@ class HaproxyRouteRequirer(Object):
             "load_balancing": {
                 "algorithm": load_balancing_algorithm,
                 "cookie": load_balancing_cookie,
+                "consistent_hashing": load_balancing_consistent_hashing,
             },
             "timeout": {
                 "server": server_timeout,

--- a/src/charm.py
+++ b/src/charm.py
@@ -51,6 +51,8 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 self._ingress.get_data(ingress_relation) if ingress_relation else None
             )
             charm_state = state.State.from_charm(self, ingress_relation_data)
+            # Assign consistent_hashing to a local variable due to line length limit
+            consistent_hashing = charm_state.load_balancing_configuration.consistent_hashing
             params = {
                 "hosts": [str(address) for address in charm_state.backend_addresses],
                 "check_interval": charm_state.health_check.interval,
@@ -69,6 +71,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 "service": charm_state.service,
                 "hostname": charm_state.hostname,
                 "additional_hostnames": charm_state.additional_hostnames,
+                "load_balancing_algorithm": charm_state.load_balancing_configuration.algorithm,
+                "load_balancing_cookie": charm_state.load_balancing_configuration.cookie,
+                "load_balancing_consistent_hashing": consistent_hashing,
             }
             not_none_params = {k: v for k, v in params.items() if v is not None}
             self._haproxy_route.provide_haproxy_route_requirements(**not_none_params)


### PR DESCRIPTION
Add new charm configs for load-balancing, including consistent hashing.

Integration tests will be added in a follow-up PR when the new revision of the haproxy charm with support for consistent hashing is released

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
