### PR TITLE
ISD-3955 haproxy add http server close attribute

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -88,6 +88,12 @@ config:
     additional-hostnames:
       type: string
       description: Comma-separated list of additional_hostnames to route to the service. Will be ignored if hostname is not set.
+    http-server-close:
+      type: boolean
+      default: false
+      description: |
+          If set to true, the server will close the connection after each request.
+          This can be useful for certain applications that do not support keep-alive.
 
 charm-libs:
   - lib: haproxy.haproxy_route

--- a/src/charm.py
+++ b/src/charm.py
@@ -69,6 +69,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 "service": charm_state.service,
                 "hostname": charm_state.hostname,
                 "additional_hostnames": charm_state.additional_hostnames,
+                "http_server_close": charm_state.http_server_close,
             }
             not_none_params = {k: v for k, v in params.items() if v is not None}
             self._haproxy_route.provide_haproxy_route_requirements(**not_none_params)

--- a/src/state.py
+++ b/src/state.py
@@ -197,6 +197,7 @@ class State:
         paths: List of URL paths to route to the service.
         hostname: The hostname to route to the service.
         additional_hostnames: List of additional hostnames to route to the service.
+        http_server_close: Configure server close after request.
     """
 
     _backend_state: BackendState
@@ -211,6 +212,7 @@ class State:
     additional_hostnames: list[Annotated[str, BeforeValidator(value_has_valid_characters)]] = (
         Field(default=[])
     )
+    http_server_close: bool = Field(default=False)
 
     @property
     def backend_addresses(self) -> list[IPvAnyAddress]:
@@ -277,6 +279,7 @@ class State:
                 if charm.config.get("additional-hostnames")
                 else []
             )
+            http_server_close = cast(bool, charm.config.get("http-server-close"))
 
             config_backend = bool(config_backend_addresses or config_backend_ports)
             ingress_backend = bool(ingress_backend_addresses or ingress_backend_ports)
@@ -294,6 +297,7 @@ class State:
                 service=f"{charm.model.name}-{charm.app.name}",
                 hostname=hostname,
                 additional_hostnames=additional_hostnames,
+                http_server_close=http_server_close,
             )
         except ValidationError as exc:
             logger.error(str(exc))

--- a/src/state.py
+++ b/src/state.py
@@ -265,7 +265,7 @@ class State:
                 if charm.config.get("additional-hostnames")
                 else []
             )
-            http_server_close = cast(bool, charm.config.get("http-server-close"))
+            http_server_close = cast(bool, charm.config.get("http-server-close", False))
 
             config_backend = bool(config_backend_addresses or config_backend_ports)
             ingress_backend = bool(ingress_backend_addresses or ingress_backend_ports)

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -37,6 +37,7 @@ def test_adapter_state_from_charm():
         "paths": "/api/v1,/api/v2",
         "hostname": "api.example.com",
         "additional-hostnames": "api2.example.com,api3.example.com",
+        "http-server-close": True,
     }
     ingress_relation_data = IngressRequirerData(
         app=IngressRequirerAppData(model="model", name="name", port=8080),
@@ -62,6 +63,7 @@ def test_adapter_state_from_charm():
     assert charm_state.paths == charm.config.get("paths").split(",")
     assert charm_state.hostname == charm.config.get("hostname")
     assert charm_state.additional_hostnames == charm.config.get("additional-hostnames").split(",")
+    assert charm_state.http_server_close == charm.config.get("http-server-close")
 
 
 def test_integrator_state_from_charm():
@@ -76,6 +78,7 @@ def test_integrator_state_from_charm():
         "backend-ports": "8080,8081",
         "retry-count": 1,
         "retry-redispatch": True,
+        "http-server-close": True,
     }
     charm_state = state.State.from_charm(charm, None)
     assert [str(address) for address in charm_state.backend_addresses] == charm.config.get(
@@ -87,6 +90,7 @@ def test_integrator_state_from_charm():
     assert charm_state.backend_protocol == "http"
     assert charm_state.retry.count == charm.config.get("retry-count")
     assert charm_state.retry.redispatch == charm.config.get("retry-redispatch")
+    assert charm_state.http_server_close == charm.config.get("http-server-close")
 
 
 def test_state_from_charm_no_backend():


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Add http-server-close attribute. If this attribute is set to `True` the connection is closed after the request.

A following PR in https://github.com/canonical/haproxy-operator respository will be opened.

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
