### PR TITLE
add limit field to ingress relation definition

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -38,6 +38,7 @@ requires:
 provides:
   ingress:
     interface: ingress
+    limit: 1
 
 config:
   options:


### PR DESCRIPTION
### Overview

fixes #59 . Prevents >1 ingress relation from being added to the charm.

### Rationale

If relating 2 applications to ingress-configurator on the ingress relation, the charm will enter error state

Unclear whether `haproxy-route` and `haproxy-route-tcp` relations also need a `limit: 1` field