### PR TITLE
test: migrate to pytest-jubilant 2

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s"'
+      extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown'
       provider: lxd
       juju-channel: 3/stable
       self-hosted-runner: true

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -10,7 +10,7 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit
     with:
-      extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s" --no-juju-teardown'
+      extra-arguments: '-x --log-format="%(asctime)s %(levelname)s %(message)s" -vv --no-juju-teardown'
       provider: lxd
       juju-channel: 3/stable
       self-hosted-runner: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ integration = [
   "allure-pytest-collection-report @ git+https://github.com/canonical/data-platform-workflows@v24.0.0#subdirectory=python/pytest_plugins/allure_pytest_collection_report",
   "jubilant",
   "pytest",
-  "pytest-jubilant<2",
+  "pytest-jubilant>=2,<3",
   "requests",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ integration = [
   "allure-pytest-collection-report @ git+https://github.com/canonical/data-platform-workflows@v24.0.0#subdirectory=python/pytest_plugins/allure_pytest_collection_report",
   "jubilant",
   "pytest",
-  "pytest-jubilant",
+  "pytest-jubilant<2",
   "requests",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,7 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="store")
+    # --keep-models is passed by reusable CI workflows
+    # It's consumed as a no-op here to avoid "unrecognized arguments" errors.
+    # pytest-jubilant v2 uses --no-juju-teardown instead.
+    parser.addoption("--keep-models", action="store_true", default=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,12 +11,3 @@ def pytest_addoption(parser):
         parser: Pytest parser.
     """
     parser.addoption("--charm-file", action="store")
-
-
-def pytest_configure(config):
-    """Adds config options.
-
-    Args:
-        config: Pytest configuration object.
-    """
-    config.addinivalue_line("markers", "abort_on_fail")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -6,11 +6,10 @@
 import json
 import pathlib
 from ipaddress import IPv4Address, IPv6Address, ip_address
-from typing import Callable, cast
+from typing import Callable
 
 import jubilant
 import pytest
-import yaml
 from requests import Session
 
 from .helper import DNSResolverAdapter
@@ -22,6 +21,7 @@ HELPER_SRC = "tests/integration/helper.py"
 INGRESS_LIB_SRC = "lib/charms/traefik_k8s/v2/ingress.py"
 APT_LIB_SRC = "lib/charms/operator_libs_linux/v0/apt.py"
 JUJU_WAIT_TIMEOUT = 10 * 60  # 10 minutes
+APP_NAME = "ingress-configurator"
 HAPROXY_APP_NAME = "haproxy"
 HAPROXY_CHANNEL = "2.8/edge"
 HAPROXY_REVISION = 244
@@ -41,59 +41,20 @@ def charm_fixture(pytestconfig: pytest.Config):
     yield charm
 
 
-@pytest.fixture(scope="module", name="juju")
-def juju_fixture(request: pytest.FixtureRequest):
-    """Pytest fixture that wraps :meth:`jubilant.with_model`."""
-    model = request.config.getoption("--model")
-    if model:
-        juju = jubilant.Juju(model=model)
-        juju.wait_timeout = JUJU_WAIT_TIMEOUT
-        yield juju
-        return
-
-    keep_models = cast(bool, request.config.getoption("--keep-models"))
-    with jubilant.temp_model(keep=keep_models) as juju:
-        juju.wait_timeout = JUJU_WAIT_TIMEOUT
-        yield juju
+@pytest.fixture(scope="module")
+def juju(juju: jubilant.Juju) -> jubilant.Juju:
+    """Wrap pytest-jubilant's juju fixture to set a custom wait timeout."""
+    juju.wait_timeout = JUJU_WAIT_TIMEOUT
+    return juju
 
 
-@pytest.fixture(scope="module", name="application")
-def application_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, charm: str):
-    """Deploy the ingress-configurator application.
-
-    Args:
-        juju: Jubilant juju fixture.
-        charm_file: Path to the packed charm file.
-
-    Yields:
-        The ingress-configurator app name.
-    """
-    metadata = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text(encoding="UTF-8"))
-    app_name = metadata["name"]
-    if pytestconfig.getoption("--no-setup") and app_name in juju.status().apps:
-        yield app_name
-        return
+def deploy_with_haproxy(juju: jubilant.Juju, charm: str):
+    """Deploy ingress-configurator, haproxy, and self-signed-certificates."""
     juju.deploy(
         charm=charm,
-        app=app_name,
+        app=APP_NAME,
         base="ubuntu@24.04",
     )
-    yield app_name
-
-
-@pytest.fixture(scope="module", name="haproxy")
-def haproxy_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
-    """_summary_
-
-    Args:
-        juju: Jubilant juju fixture.
-
-    Yields:
-        The haproxy app name.
-    """
-    if pytestconfig.getoption("--no-setup") and HAPROXY_APP_NAME in juju.status().apps:
-        yield HAPROXY_APP_NAME
-        return
     juju.deploy(
         charm="haproxy",
         app=HAPROXY_APP_NAME,
@@ -109,18 +70,12 @@ def haproxy_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
         revision=CERTIFICATES_REVISION,
     )
     juju.integrate(f"{CERTIFICATES_APP_NAME}:certificates", f"{HAPROXY_APP_NAME}:certificates")
-    juju.wait(
-        lambda status: jubilant.all_active(status, HAPROXY_APP_NAME, CERTIFICATES_APP_NAME),
-    )
-    yield HAPROXY_APP_NAME
+    apps = (APP_NAME, HAPROXY_APP_NAME, CERTIFICATES_APP_NAME)
+    juju.wait(lambda status: jubilant.all_active(status, *apps))
 
 
-@pytest.fixture(scope="module", name="any_charm_backend")
-def any_charm_backend_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
+def deploy_any_charm_backend(juju: jubilant.Juju):
     """Deploy any-charm and configure it to serve as a requirer for the http interface."""
-    if pytestconfig.getoption("--no-setup") and ANY_CHARM_APP_NAME in juju.status().apps:
-        yield ANY_CHARM_APP_NAME
-        return
     juju.deploy(
         charm="any-charm",
         channel="beta",
@@ -142,7 +97,6 @@ def any_charm_backend_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
     for unit in juju.status().apps[ANY_CHARM_APP_NAME].units:
         juju.run(unit, "rpc", {"method": "start_server"})
     juju.wait(lambda status: jubilant.all_active(status, ANY_CHARM_APP_NAME))
-    yield ANY_CHARM_APP_NAME
 
 
 @pytest.fixture(scope="module")
@@ -166,12 +120,8 @@ def http_session() -> Callable[[list[tuple[str, IPv4Address | IPv6Address]]], Se
     return _make_session
 
 
-@pytest.fixture(scope="module", name="ingress_requirer")
-def ingress_requirer_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, application: str):
+def deploy_ingress_requirer(juju: jubilant.Juju):
     """Deploy and configure any-charm to serve as an ingress requirer for the ingress interface."""
-    if pytestconfig.getoption("--no-setup") and INGRESS_REQUIRER_APP_NAME in juju.status().apps:
-        yield INGRESS_REQUIRER_APP_NAME
-        return
     juju.deploy(
         charm="any-charm",
         channel="beta",
@@ -188,16 +138,12 @@ def ingress_requirer_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, a
             "python-packages": "pydantic",
         },
     )
-    juju.wait(
-        lambda status: jubilant.all_active(
-            status, INGRESS_REQUIRER_APP_NAME, "self-signed-certificates"
-        )
-    )
+    apps = (INGRESS_REQUIRER_APP_NAME, CERTIFICATES_APP_NAME)
+    juju.wait(lambda status: jubilant.all_active(status, *apps))
     for unit in juju.status().apps[INGRESS_REQUIRER_APP_NAME].units:
         juju.run(unit, "rpc", {"method": "start_server"})
-    juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", f"{application}:ingress")
+    juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", f"{APP_NAME}:ingress")
     juju.wait(lambda status: jubilant.all_active(status, INGRESS_REQUIRER_APP_NAME))
-    yield INGRESS_REQUIRER_APP_NAME
 
 
 def get_unit_addresses(juju: jubilant.Juju, application: str) -> list[IPv4Address | IPv6Address]:
@@ -217,20 +163,8 @@ def get_unit_addresses(juju: jubilant.Juju, application: str) -> list[IPv4Addres
     return unit_addresses
 
 
-@pytest.fixture(scope="module", name="application_with_tcp_server")
-def application_with_tcp_server_fixture(application: str, juju: jubilant.Juju):
-    """Deploy the ingress-configurator application.
-
-    Args:
-        application: The ingress-configurator application name.
-        juju: Jubilant juju fixture.
-
-    Yields:
-        The ingress-configurator app name.
-    """
-    juju.wait(
-        lambda status: jubilant.all_active(status, application),
-    )
+def setup_tcp_server(juju: jubilant.Juju):
+    """Set up the TCP ping-pong server on the application."""
+    juju.wait(lambda status: jubilant.all_active(status, APP_NAME))
     command = "sudo snap install ping-pong-tcp; sudo snap set ping-pong-tcp host=0.0.0.0"
-    juju.ssh(target=f"{application}/0", command=command)
-    yield application
+    juju.ssh(target=f"{APP_NAME}/0", command=command)

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -6,35 +6,39 @@
 import json
 
 import jubilant
+import pytest
 
-from .conftest import MOCK_HAPROXY_HOSTNAME
+from .conftest import (
+    APP_NAME,
+    HAPROXY_APP_NAME,
+    INGRESS_REQUIRER_APP_NAME,
+    MOCK_HAPROXY_HOSTNAME,
+    deploy_ingress_requirer,
+    deploy_with_haproxy,
+)
 
 
-def test_action_get_proxied_endpoints_nominal(
-    juju: jubilant.Juju,
-    application: str,
-    haproxy: str,
-    ingress_requirer: str,
-):
-    """Test the charm actions in integrator mode.
+@pytest.mark.juju_setup
+def test_deploy_with_haproxy(juju: jubilant.Juju, charm: str):
+    deploy_with_haproxy(juju, charm)
 
-    Args:
-        juju: Jubilant juju fixture
-        application: Name of the ingress-configurator application.
-        haproxy: Name of the haproxy application.
-        ingress_requirer: Any charm running an apache webserver.
-    """
+
+@pytest.mark.juju_setup
+def test_deploy_ingress_requirer(juju: jubilant.Juju):
+    deploy_ingress_requirer(juju)
+
+
+def test_action_get_proxied_endpoints_nominal(juju: jubilant.Juju):
+    """Test the charm actions in integrator mode."""
     juju.config(
-        haproxy,
+        HAPROXY_APP_NAME,
         {"external-hostname": f"{MOCK_HAPROXY_HOSTNAME}"},
     )
-    juju.integrate(f"{haproxy}:haproxy-route", f"{application}:haproxy-route")
+    juju.integrate(f"{HAPROXY_APP_NAME}:haproxy-route", f"{APP_NAME}:haproxy-route")
 
-    juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, ingress_requirer),
-        error=jubilant.any_error,
-    )
-    unit = next(iter(juju.status().apps[application].units))
+    apps = (HAPROXY_APP_NAME, APP_NAME, INGRESS_REQUIRER_APP_NAME)
+    juju.wait(lambda status: jubilant.all_active(status, *apps), error=jubilant.any_error)
+    unit = next(iter(juju.status().apps[APP_NAME].units))
 
     # Test with no configured hostname on ingress configurator
     task = juju.run(unit, "get-proxied-endpoints")
@@ -43,26 +47,17 @@ def test_action_get_proxied_endpoints_nominal(
     # Test with configured hostname on ingress
     hostname = "test.ingress.hostname"
     juju.config(
-        application,
+        APP_NAME,
         {"hostname": hostname},
     )
-    juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, ingress_requirer),
-        error=jubilant.any_error,
-    )
+    juju.wait(lambda status: jubilant.all_active(status, *apps), error=jubilant.any_error)
     task = juju.run(unit, "get-proxied-endpoints")
     assert task.results == {"endpoints": f'["https://{hostname}/"]'}, task.results
 
     # Test with configured additional_hostnames on ingress
     additional_hostnames = ["test1.ingress.addition_hostname", "test2.ingress.addition_hostname"]
-    juju.config(
-        application,
-        {"additional-hostnames": ",".join(additional_hostnames)},
-    )
-    juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, ingress_requirer),
-        error=jubilant.any_error,
-    )
+    juju.config(APP_NAME, {"additional-hostnames": ",".join(additional_hostnames)})
+    juju.wait(lambda status: jubilant.all_active(status, *apps), error=jubilant.any_error)
     task = juju.run(unit, "get-proxied-endpoints")
 
     endpoints = set(json.loads(task.results["endpoints"]))

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -4,6 +4,7 @@
 """Test the charm in integrator mode."""
 
 import json
+import time
 
 import jubilant
 import pytest
@@ -58,7 +59,12 @@ def test_action_get_proxied_endpoints_nominal(juju: jubilant.Juju):
     additional_hostnames = ["test1.ingress.addition_hostname", "test2.ingress.addition_hostname"]
     juju.config(APP_NAME, {"additional-hostnames": ",".join(additional_hostnames)})
     juju.wait(lambda status: jubilant.all_active(status, *apps), error=jubilant.any_error)
-    task = juju.run(unit, "get-proxied-endpoints")
-
-    endpoints = set(json.loads(task.results["endpoints"]))
-    assert endpoints == {f"https://{h}/" for h in [hostname, *additional_hostnames]}, task.results
+    for i in range(5):
+        if i:  # We're retrying, wait first.
+            time.sleep(60)
+        task = juju.run(unit, "get-proxied-endpoints")
+        endpoints = set(json.loads(task.results["endpoints"]))
+        if endpoints == {f"https://{h}/" for h in [hostname, *additional_hostnames]}:
+            break
+    else:  # no break
+        raise AssertionError(f"Endpoints did not match expected set after 5 attempts: {endpoints}")

--- a/tests/integration/test_adapter.py
+++ b/tests/integration/test_adapter.py
@@ -1,73 +1,64 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Test the charm in integrator mode."""
+"""Test the charm in adapter mode."""
 
 from typing import Callable
 
 import jubilant
+import pytest
 from requests import Session
 
-from .conftest import MOCK_HAPROXY_HOSTNAME, get_unit_addresses
+from .conftest import (
+    APP_NAME,
+    HAPROXY_APP_NAME,
+    INGRESS_REQUIRER_APP_NAME,
+    MOCK_HAPROXY_HOSTNAME,
+    deploy_ingress_requirer,
+    deploy_with_haproxy,
+    get_unit_addresses,
+)
 
 
-def test_adapter_end_to_end_routing(
-    juju: jubilant.Juju,
-    application: str,
-    haproxy: str,
-    ingress_requirer: str,
-    http_session: Callable[..., Session],
-):
-    """Test for integrator mode.
+@pytest.mark.juju_setup
+def test_deploy_with_haproxy(juju: jubilant.Juju, charm: str):
+    deploy_with_haproxy(juju, charm)
 
-    Args:
-        juju: Jubilant juju fixture
-        application: Name of the ingress-configurator application.
-        haproxy: Name of the haproxy application.
-        ingress_requirer: Any charm running an apache webserver.
-        http_session: Modified requests session fixture for making HTTP requests.
-    """
-    juju.integrate(f"{haproxy}:haproxy-route", f"{application}:haproxy-route")
-    juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, ingress_requirer),
-        error=jubilant.any_error,
-    )
+
+@pytest.mark.juju_setup
+def test_deploy_ingress_requirer(juju: jubilant.Juju):
+    deploy_ingress_requirer(juju)
+
+
+def test_adapter_end_to_end_routing(juju: jubilant.Juju, http_session: Callable[..., Session]):
+    """Test for integrator mode."""
+    juju.integrate(f"{HAPROXY_APP_NAME}:haproxy-route", f"{APP_NAME}:haproxy-route")
+    apps = (HAPROXY_APP_NAME, APP_NAME, INGRESS_REQUIRER_APP_NAME)
+    juju.wait(lambda status: jubilant.all_active(status, *apps), error=jubilant.any_error)
 
     session = http_session(
-        dns_entries=[(MOCK_HAPROXY_HOSTNAME, str(get_unit_addresses(juju, haproxy)[0]))]
+        dns_entries=[(MOCK_HAPROXY_HOSTNAME, str(get_unit_addresses(juju, HAPROXY_APP_NAME)[0]))]
     )
     response = session.get(f"https://{MOCK_HAPROXY_HOSTNAME}", verify=False, timeout=30)
     assert "Apache2 Default Page" in response.text
 
 
-def test_adapter_http(
-    juju: jubilant.Juju,
-    application: str,
-    haproxy: str,
-    ingress_requirer: str,
-    http_session: Callable[..., Session],
-):
-    """Test for allow-http config.
-
-    Args:
-        juju: Jubilant juju fixture
-        application: Name of the ingress-configurator application.
-        haproxy: Name of the haproxy application.
-        ingress_requirer: Any charm running an apache webserver.
-        http_session: Modified requests session fixture for making HTTP requests.
-    """
+def test_adapter_http(juju: jubilant.Juju, http_session: Callable[..., Session]):
+    """Test for allow-http config."""
     juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, ingress_requirer),
+        lambda status: jubilant.all_active(
+            status, HAPROXY_APP_NAME, APP_NAME, INGRESS_REQUIRER_APP_NAME
+        ),
         error=jubilant.any_error,
     )
-    addr = str(get_unit_addresses(juju, haproxy)[0])
+    addr = str(get_unit_addresses(juju, HAPROXY_APP_NAME)[0])
     session = http_session(dns_entries=[(MOCK_HAPROXY_HOSTNAME, addr)])
 
     response = session.get(f"http://{MOCK_HAPROXY_HOSTNAME}", verify=False, timeout=30)
     assert response.history[0].status_code == 302
-    juju.config(application, {"allow-http": True})
+    juju.config(APP_NAME, {"allow-http": True})
     juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application),
+        lambda status: jubilant.all_active(status, HAPROXY_APP_NAME, APP_NAME),
         error=jubilant.any_error,
     )
 

--- a/tests/integration/test_haproxy_route_tcp.py
+++ b/tests/integration/test_haproxy_route_tcp.py
@@ -11,28 +11,39 @@ import time
 import jubilant
 import pytest
 
-from .conftest import get_unit_addresses
+from .conftest import (
+    APP_NAME,
+    HAPROXY_APP_NAME,
+    deploy_with_haproxy,
+    get_unit_addresses,
+    setup_tcp_server,
+)
 
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
-def test_haproxy_route_tcp(
-    application_with_tcp_server: str,
-    haproxy: str,
-    juju: jubilant.Juju,
-):
+@pytest.mark.juju_setup
+def test_deploy_with_haproxy(juju: jubilant.Juju, charm: str):
+    deploy_with_haproxy(juju, charm)
+
+
+@pytest.mark.juju_setup
+def test_setup_tcp_server(juju: jubilant.Juju):
+    setup_tcp_server(juju)
+
+
+def test_haproxy_route_tcp(juju: jubilant.Juju):
     """Deploy the charm with anycharm ingress per unit requirer that installs apache2.
 
     Assert that the requirer endpoints are available.
     """
     juju.integrate(
-        f"{haproxy}:haproxy-route-tcp",
-        application_with_tcp_server,
+        f"{HAPROXY_APP_NAME}:haproxy-route-tcp",
+        APP_NAME,
     )
-    application_ip_address = get_unit_addresses(juju, application_with_tcp_server)[0]
+    application_ip_address = get_unit_addresses(juju, APP_NAME)[0]
     juju.config(
-        application_with_tcp_server,
+        APP_NAME,
         {
             "tcp-frontend-port": 4444,
             "tcp-backend-port": 4000,
@@ -42,10 +53,8 @@ def test_haproxy_route_tcp(
         },
     )
 
-    juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application_with_tcp_server), delay=5
-    )
-    haproxy_ip_address = get_unit_addresses(juju, haproxy)[0]
+    juju.wait(lambda status: jubilant.all_active(status, HAPROXY_APP_NAME, APP_NAME), delay=5)
+    haproxy_ip_address = get_unit_addresses(juju, HAPROXY_APP_NAME)[0]
     context = ssl._create_unverified_context()  # pylint: disable=protected-access  # nosec
     deadline = time.time() + 30
     address = (str(haproxy_ip_address), 4444)

--- a/tests/integration/test_integrator.py
+++ b/tests/integration/test_integrator.py
@@ -9,32 +9,35 @@ import jubilant
 import pytest
 from requests import Session
 
-from .conftest import MOCK_HAPROXY_HOSTNAME, get_unit_addresses
+from .conftest import (
+    ANY_CHARM_APP_NAME,
+    APP_NAME,
+    HAPROXY_APP_NAME,
+    MOCK_HAPROXY_HOSTNAME,
+    deploy_any_charm_backend,
+    deploy_with_haproxy,
+    get_unit_addresses,
+)
 
 
-@pytest.mark.abort_on_fail
-def test_config_hostnames_and_paths(
-    juju: jubilant.Juju,
-    application: str,
-    haproxy: str,
-    any_charm_backend: str,
-    http_session: Callable[..., Session],
-):
-    """Test the charm configuration in integrator mode.
+@pytest.mark.juju_setup
+def test_deploy_with_haproxy(juju: jubilant.Juju, charm: str):
+    deploy_with_haproxy(juju, charm)
 
-    Args:
-        juju: Jubilant juju fixture
-        application: Name of the ingress-configurator application.
-        haproxy: Name of the haproxy application.
-        any_charm_backend: Any charm running an apache webserver.
-        http_session: Modified requests session fixture for making HTTP requests.
-    """
-    juju.integrate(f"{haproxy}:haproxy-route", f"{application}:haproxy-route")
+
+@pytest.mark.juju_setup
+def test_deploy_any_charm_backend(juju: jubilant.Juju):
+    deploy_any_charm_backend(juju)
+
+
+def test_config_hostnames_and_paths(juju: jubilant.Juju, http_session: Callable[..., Session]):
+    """Test the charm configuration in integrator mode."""
+    juju.integrate(f"{HAPROXY_APP_NAME}:haproxy-route", f"{APP_NAME}:haproxy-route")
     backend_addresses = ",".join(
-        [str(address) for address in get_unit_addresses(juju, any_charm_backend)]
+        [str(address) for address in get_unit_addresses(juju, ANY_CHARM_APP_NAME)]
     )
     juju.config(
-        app=application,
+        app=APP_NAME,
         values={
             "backend-addresses": backend_addresses,
             "backend-ports": 80,
@@ -42,11 +45,11 @@ def test_config_hostnames_and_paths(
         },
     )
     juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, any_charm_backend),
+        lambda status: jubilant.all_active(status, HAPROXY_APP_NAME, APP_NAME, ANY_CHARM_APP_NAME),
         error=jubilant.any_error,
     )
 
-    haproxy_address = str(get_unit_addresses(juju, haproxy)[0])
+    haproxy_address = str(get_unit_addresses(juju, HAPROXY_APP_NAME)[0])
     session = http_session(
         dns_entries=[
             (MOCK_HAPROXY_HOSTNAME, haproxy_address),
@@ -63,7 +66,7 @@ def test_config_hostnames_and_paths(
         assert response.status_code == 200 and f"{path_component} ok!" in response.text
 
     juju.config(
-        app=application,
+        app=APP_NAME,
         values={
             "paths": "/api/v1",
             "hostname": f"api.{MOCK_HAPROXY_HOSTNAME}",
@@ -71,7 +74,7 @@ def test_config_hostnames_and_paths(
         },
     )
     juju.wait(
-        lambda status: jubilant.all_active(status, haproxy, application, any_charm_backend),
+        lambda status: jubilant.all_active(status, HAPROXY_APP_NAME, APP_NAME, ANY_CHARM_APP_NAME),
         error=jubilant.any_error,
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -328,7 +328,7 @@ integration = [
     { name = "allure-pytest-collection-report", git = "https://github.com/canonical/data-platform-workflows?subdirectory=python%2Fpytest_plugins%2Fallure_pytest_collection_report&rev=v24.0.0" },
     { name = "jubilant" },
     { name = "pytest" },
-    { name = "pytest-jubilant" },
+    { name = "pytest-jubilant", specifier = "<2" },
     { name = "requests" },
 ]
 lint = [
@@ -658,15 +658,15 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "0.7.1"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/20/a35203e1ba501c0eeb826917b023e3c8d06ee965741ac8245155e7628f84/pytest_jubilant-0.7.1.tar.gz", hash = "sha256:0a69a352d9da01b2e02331ef392baee1127f58f0529cf5ae9660a2bcf7f62b09", size = 11734, upload-time = "2025-07-07T13:31:32.521Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/31/2726f3a38c94036434e5744fd727e517495814692aa79f5200444dd5d18a/pytest_jubilant-1.3.0.tar.gz", hash = "sha256:93e05233172e33a76f96e162fd9aeb5161f453abd7de521183631857bb77a8ea", size = 12752, upload-time = "2026-03-13T02:04:14.435Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/d9/4544a16eb660da6d467f2565ca5be2c520df8a2d0611f8d657ddb92498a4/pytest_jubilant-0.7.1-py3-none-any.whl", hash = "sha256:1d89321ed6728fa412c5bd6112856e42c7f5e5905587657bd53b2158f7488bfd", size = 11811, upload-time = "2025-07-07T13:31:31.151Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/85/07093962c95599bc27ee35734951466fcb367f2ce24f8a9cac6f297a789a/pytest_jubilant-1.3.0-py3-none-any.whl", hash = "sha256:520c04f5a4a5d1d9e3729424d4f8bd6b01153c0284fb3e2fda8fe90fae79cc4a", size = 11831, upload-time = "2026-03-13T02:04:13.131Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -328,7 +328,7 @@ integration = [
     { name = "allure-pytest-collection-report", git = "https://github.com/canonical/data-platform-workflows?subdirectory=python%2Fpytest_plugins%2Fallure_pytest_collection_report&rev=v24.0.0" },
     { name = "jubilant" },
     { name = "pytest" },
-    { name = "pytest-jubilant", specifier = "<2" },
+    { name = "pytest-jubilant", specifier = ">=2,<3" },
     { name = "requests" },
 ]
 lint = [
@@ -658,15 +658,15 @@ wheels = [
 
 [[package]]
 name = "pytest-jubilant"
-version = "1.3.0"
+version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jubilant" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8a/31/2726f3a38c94036434e5744fd727e517495814692aa79f5200444dd5d18a/pytest_jubilant-1.3.0.tar.gz", hash = "sha256:93e05233172e33a76f96e162fd9aeb5161f453abd7de521183631857bb77a8ea", size = 12752, upload-time = "2026-03-13T02:04:14.435Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/64/e83181af1004f64a3ce11c7b9770c3152832e02d00e9e7b4f01877325c5f/pytest_jubilant-2.0.1.tar.gz", hash = "sha256:960bb63d216ec746f7644b67c276b059fccdaa258ee7644aaa74058db659edac", size = 16311, upload-time = "2026-04-07T02:08:25.874Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/85/07093962c95599bc27ee35734951466fcb367f2ce24f8a9cac6f297a789a/pytest_jubilant-1.3.0-py3-none-any.whl", hash = "sha256:520c04f5a4a5d1d9e3729424d4f8bd6b01153c0284fb3e2fda8fe90fae79cc4a", size = 11831, upload-time = "2026-03-13T02:04:13.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3c/5c0bc4f54f6905aa7515cf764c3f5d6c85711cdc1a928221f711d5b7532c/pytest_jubilant-2.0.1-py3-none-any.whl", hash = "sha256:df498ee79d6db5ec32baa35a121ab75852dd50f61504a12550ba81cd63a7f1ef", size = 13525, upload-time = "2026-04-07T02:08:24.531Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Overview

This PR migrates the integration tests `pytest-jubilant` to 2.

### Rationale

The [2.0 release](https://github.com/canonical/pytest-jubilant/releases/tag/v2.0.0) contains many breaking changes, and the 1.0 release will not be supported long term.

The test suite inspected the `--no-setup` flag to determine whether some fixtures should deploy charms. This has been rewritten use test functions with the [juju_setup marker](https://github.com/canonical/pytest-jubilant?tab=readme-ov-file#juju_setup) instead.

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
