### PR TITLE
Disable jubilant logging for juju.deploy, juju.config and juju.exec

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -135,11 +135,7 @@ def application_fixture(
     if pytestconfig.getoption("--no-setup") and app_name in juju.status().apps:
         yield app_name
         return
-    juju.deploy(
-        charm=charm,
-        app=app_name,
-        base="ubuntu@24.04",
-    )
+    juju.deploy(charm=charm, app=app_name, base="ubuntu@24.04", log=False)
     yield app_name
 
 
@@ -163,12 +159,14 @@ def haproxy_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju):
         revision=HAPROXY_REVISION,
         config={"external-hostname": MOCK_HAPROXY_HOSTNAME},
         base=HAPROXY_BASE,
+        log=False,
     )
     juju.deploy(
         charm="self-signed-certificates",
         app=CERTIFICATES_APP_NAME,
         channel=CERTIFICATES_CHANNEL,
         revision=CERTIFICATES_REVISION,
+        log=False,
     )
     juju.integrate(f"{CERTIFICATES_APP_NAME}:certificates", f"{HAPROXY_APP_NAME}:certificates")
     juju.offer(HAPROXY_APP_NAME, endpoint="haproxy-route")
@@ -197,6 +195,7 @@ def any_charm_backend_fixture(
             ),
         },
         num_units=2,
+        log=False,
     )
     yield ANY_CHARM_APP_NAME
 
@@ -243,6 +242,7 @@ def ingress_requirer_fixture(pytestconfig: pytest.Config, juju: jubilant.Juju, a
             ),
             "python-packages": "pydantic",
         },
+        log=False,
     )
     juju.integrate(f"{INGRESS_REQUIRER_APP_NAME}:ingress", f"{application}:ingress")
     yield INGRESS_REQUIRER_APP_NAME
@@ -302,7 +302,7 @@ def k8s_ingress_requirer_fixture(
     metadata = yaml.safe_load(pathlib.Path("./charmcraft.yaml").read_text(encoding="UTF-8"))
     app_name = metadata["name"]
 
-    juju_k8s.deploy(charm=charm, app=app_name, trust=True)
+    juju_k8s.deploy(charm=charm, app=app_name, trust=True, log=False)
     juju_k8s.deploy(
         charm="any-charm",
         channel="beta",
@@ -318,6 +318,7 @@ def k8s_ingress_requirer_fixture(
             ),
             "python-packages": "pydantic",
         },
+        log=False,
     )
     juju_k8s.integrate(
         f"{app_name}:haproxy-route", f"{lxd_controller}:admin/{lxd_model}.{HAPROXY_APP_NAME}"

--- a/tests/integration/test_actions.py
+++ b/tests/integration/test_actions.py
@@ -21,10 +21,7 @@ def test_action_get_proxied_endpoints_nominal(
         haproxy: Name of the haproxy application.
         ingress_requirer: Any charm running an apache webserver.
     """
-    juju.config(
-        haproxy,
-        {"external-hostname": f"{MOCK_HAPROXY_HOSTNAME}"},
-    )
+    juju.config(haproxy, {"external-hostname": f"{MOCK_HAPROXY_HOSTNAME}"}, log=False)
     juju.integrate(f"{haproxy}:haproxy-route", f"{application}:haproxy-route")
 
     juju.wait(
@@ -40,10 +37,7 @@ def test_action_get_proxied_endpoints_nominal(
 
     # Test with configured hostname on ingress
     hostname = "test.ingress.hostname"
-    juju.config(
-        application,
-        {"hostname": hostname},
-    )
+    juju.config(application, {"hostname": hostname}, log=False)
     juju.wait(
         lambda status: jubilant.all_agents_idle(status, haproxy, application, ingress_requirer)
     )
@@ -55,10 +49,7 @@ def test_action_get_proxied_endpoints_nominal(
         "test1.ingress.addition_hostname",
         "test2.ingress.addition_hostname",
     ]
-    juju.config(
-        application,
-        {"additional-hostnames": ",".join(additional_hostnames)},
-    )
+    juju.config(application, {"additional-hostnames": ",".join(additional_hostnames)}, log=False)
     juju.wait(
         lambda status: jubilant.all_agents_idle(status, haproxy, application, ingress_requirer)
     )

--- a/tests/integration/test_adapter.py
+++ b/tests/integration/test_adapter.py
@@ -67,7 +67,7 @@ def test_adapter_http(
 
     response = session.get(f"http://{MOCK_HAPROXY_HOSTNAME}", verify=False, timeout=30)
     assert response.history[0].status_code == 302
-    juju.config(application, {"allow-http": True})
+    juju.config(application, {"allow-http": True}, log=False)
     juju.wait(
         lambda status: jubilant.all_active(status, haproxy, application),
         error=jubilant.any_error,

--- a/tests/integration/test_haproxy_route_tcp.py
+++ b/tests/integration/test_haproxy_route_tcp.py
@@ -39,6 +39,7 @@ def test_haproxy_route_tcp(application_with_tcp_server: str, haproxy: str, juju:
             "tcp-tls-terminate": True,
             "tcp-backend-addresses": str(application_ip_address),
         },
+        log=False,
     )
 
     juju.wait(

--- a/tests/integration/test_ingress_kubernetes.py
+++ b/tests/integration/test_ingress_kubernetes.py
@@ -124,7 +124,7 @@ def _get_haproxy_backend_server_ips(machine_model: jubilant.Juju, service_name: 
         A list of IP address strings found in the backend section's server lines.
     """
     unit = next(iter(machine_model.status().apps[HAPROXY_APP_NAME].units))
-    task = machine_model.exec("cat /etc/haproxy/haproxy.cfg", unit=unit)
+    task = machine_model.exec("cat /etc/haproxy/haproxy.cfg", unit=unit, log=False)
     config = task.stdout
 
     backend_match = re.search(

--- a/tests/integration/test_integrator.py
+++ b/tests/integration/test_integrator.py
@@ -45,6 +45,7 @@ def test_config_hostnames_and_paths(
             "backend-ports": 80,
             "paths": "/api/v1,/api/v2",
         },
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(
@@ -76,6 +77,7 @@ def test_config_hostnames_and_paths(
             "hostname": f"api.{MOCK_HAPROXY_HOSTNAME}",
             "additional-hostnames": f"api2.{MOCK_HAPROXY_HOSTNAME},api3.{MOCK_HAPROXY_HOSTNAME}",
         },
+        log=False,
     )
     juju.wait(
         lambda status: jubilant.all_active(status, haproxy, application, any_charm_backend),


### PR DESCRIPTION
Add log=False to all juju.deploy(), juju.config() and juju.exec() calls in integration tests.