### PR TITLE
feat: add backend timeouts for haproxy-route-tcp relation

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -203,6 +203,15 @@ config:
       description: |
         Database user for health checks.
         Only used when tcp-health-check-type is "mysql" or "postgres".
+    tcp-timeout-server:
+      type: int
+      description: Timeout for requests from haproxy to backend servers in seconds.
+    tcp-timeout-connect:
+      type: int
+      description: Timeout for client requests to haproxy in seconds.
+    tcp-timeout-queue:
+      type: int
+      description: Timeout for requests waiting in queue in seconds.
     allow-http:
       type: boolean
       default: false

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-04-20
+
+### Added
+
+- Added config options `tcp-timeout-server`, `tcp-timeout-connect`, and `tcp-timeout-queue`.
+
 ## 2026-03-17
 
 ### Added

--- a/src/charm.py
+++ b/src/charm.py
@@ -216,6 +216,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 check_send=tcp_requirements.health_check.send,
                 check_expect=tcp_requirements.health_check.expect,
                 check_db_user=tcp_requirements.health_check.db_user,
+                server_timeout=tcp_requirements.timeout.server,
+                connect_timeout=tcp_requirements.timeout.connect,
+                queue_timeout=tcp_requirements.timeout.queue,
             )
         except (InvalidHaproxyRouteTcpRequirementsError, DataValidationError) as exc:
             raise ProvideHaproxyRouteTcpRequirementsError(

--- a/src/state/haproxy_route_tcp.py
+++ b/src/state/haproxy_route_tcp.py
@@ -33,6 +33,37 @@ class InvalidHaproxyRouteTcpRequirementsError(Exception):
 
 
 @dataclass(frozen=True)
+class TCPTimeout:
+    """TCP backend timeout configuration.
+
+    Attributes:
+        server: Server timeout in seconds.
+        connect: Connect timeout in seconds.
+        queue: Queue timeout in seconds.
+    """
+
+    server: Optional[int] = Field(default=None, gt=0)
+    connect: Optional[int] = Field(default=None, gt=0)
+    queue: Optional[int] = Field(default=None, gt=0)
+
+    @classmethod
+    def from_charm(cls, charm: ops.CharmBase) -> Self:
+        """Create a TCPTimeout from charm config.
+
+        Args:
+            charm: The charm instance.
+
+        Returns:
+            TCPTimeout instance.
+        """
+        return cls(
+            server=cast(Optional[int], charm.config.get("tcp-timeout-server")),
+            connect=cast(Optional[int], charm.config.get("tcp-timeout-connect")),
+            queue=cast(Optional[int], charm.config.get("tcp-timeout-queue")),
+        )
+
+
+@dataclass(frozen=True)
 class TCPHealthCheck:
     """TCP health check configuration.
 
@@ -141,6 +172,7 @@ class HaproxyRouteTcpRequirements:  # pylint: disable=too-many-instance-attribut
     load_balancing_configuration: TCPLoadBalancingConfiguration
     enforce_tls: bool
     health_check: TCPHealthCheck
+    timeout: TCPTimeout
 
     @classmethod
     def from_charm(cls, charm: ops.CharmBase) -> Self:
@@ -196,6 +228,7 @@ class HaproxyRouteTcpRequirements:  # pylint: disable=too-many-instance-attribut
                 load_balancing_configuration=load_balancing_configuration,
                 enforce_tls=enforce_tls,
                 health_check=TCPHealthCheck.from_charm(charm),
+                timeout=TCPTimeout.from_charm(charm),
             )
         except ValidationError as exc:
             logger.error(

--- a/tests/unit/test_state_haproxy_route_tcp.py
+++ b/tests/unit/test_state_haproxy_route_tcp.py
@@ -645,3 +645,79 @@ def test_haproxy_route_tcp_requirements_invalid_health_check_type():
     with pytest.raises(InvalidHaproxyRouteTcpRequirementsError) as exc_info:
         HaproxyRouteTcpRequirements.from_charm(charm)
     assert "Invalid health check type" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "timeout_config,expected_server,expected_connect,expected_queue",
+    [
+        pytest.param(
+            {
+                "tcp-timeout-server": 10,
+                "tcp-timeout-connect": 3,
+                "tcp-timeout-queue": 5,
+            },
+            10,
+            3,
+            5,
+            id="with_timeout",
+        ),
+        pytest.param({}, None, None, None, id="without_timeout"),
+    ],
+)
+def test_haproxy_route_tcp_requirements_timeout_presence(
+    timeout_config, expected_server, expected_connect, expected_queue
+):
+    """
+    arrange: mock a charm with/without timeout configuration
+    act: instantiate HaproxyRouteTcpRequirements
+    assert: timeout values match expected
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "tcp-backend-addresses": "192.168.1.1",
+        "tcp-frontend-port": 443,
+        "tcp-backend-port": 8443,
+        "tcp-tls-terminate": True,
+        "tcp-hostname": None,
+        "tcp-load-balancing-algorithm": "leastconn",
+        "tcp-load-balancing-consistent-hashing": False,
+        "tcp-enforce-tls": True,
+        **timeout_config,
+    }
+
+    requirements = HaproxyRouteTcpRequirements.from_charm(charm)
+
+    assert requirements.timeout.server == expected_server
+    assert requirements.timeout.connect == expected_connect
+    assert requirements.timeout.queue == expected_queue
+
+
+@pytest.mark.parametrize(
+    "invalid_value",
+    [
+        {"tcp-timeout-server": -1, "tcp-timeout-connect": 3, "tcp-timeout-queue": 5},
+        {"tcp-timeout-server": 10, "tcp-timeout-connect": 0, "tcp-timeout-queue": 5},
+        {"tcp-timeout-server": 10, "tcp-timeout-connect": 3, "tcp-timeout-queue": -5},
+    ],
+)
+def test_haproxy_route_tcp_requirements_invalid_timeout_values(invalid_value):
+    """
+    arrange: mock a charm with invalid timeout values
+    act: instantiate HaproxyRouteTcpRequirements
+    assert: InvalidHaproxyRouteTcpRequirementsError is raised
+    """
+    charm = Mock(CharmBase)
+    charm.config = {
+        "tcp-backend-addresses": "192.168.1.1",
+        "tcp-frontend-port": 443,
+        "tcp-backend-port": 8443,
+        "tcp-tls-terminate": True,
+        "tcp-hostname": None,
+        "tcp-load-balancing-algorithm": "leastconn",
+        "tcp-load-balancing-consistent-hashing": False,
+        **invalid_value,
+    }
+
+    with pytest.raises(InvalidHaproxyRouteTcpRequirementsError) as exc_info:
+        HaproxyRouteTcpRequirements.from_charm(charm)
+    assert "Invalid haproxy-route-tcp configuration" in str(exc_info.value)


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

Added options to set backend timeouts for `haproxy-route-tcp` relation

### Rationale

<!-- The reason the change is needed -->

Since HAProxy is supporting setting them via the relation

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

N/A

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

N/A

### Library Changes

<!-- Any changes to charm libraries -->

N/A

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
