### PR TITLE
update validator on hostname and additional_hostnames to allow for a port component

### DIFF
--- a/src/state/charm_state.py
+++ b/src/state/charm_state.py
@@ -30,10 +30,12 @@ class InvalidStateError(Exception):
 
 
 def valid_domain_with_wildcard_and_port(value: str) -> str:
-    """Validate if value is a valid domain that can include a wildcard.
+    """Validate if value is a valid domain that can include a wildcard and a port component.
 
     The wildcard character (*) can't be at the TLD level, for example *.com is not valid.
     This is supported natively by the library ( e.g domain("com") will raise a ValidationError ).
+
+    The port component must be a valid port (integer between 1 and 65535).
 
     Raises:
         ValueError: When value is not a valid domain.

--- a/src/state/charm_state.py
+++ b/src/state/charm_state.py
@@ -29,6 +29,28 @@ class InvalidStateError(Exception):
     """Exception raised when the state is invalid."""
 
 
+def valid_domain_with_wildcard_and_port(value: str) -> str:
+    """Validate if value is a valid domain that can include a wildcard.
+
+    The wildcard character (*) can't be at the TLD level, for example *.com is not valid.
+    This is supported natively by the library ( e.g domain("com") will raise a ValidationError ).
+
+    Raises:
+        ValueError: When value is not a valid domain.
+
+    Args:
+        value: The value to validate.
+    """
+    if (fqdn_components := value.split(":")) and len(fqdn_components) == 2:
+        valid_domain_with_wildcard(fqdn_components[0])
+        # ValueError from int() is also wrapped by pydantic.
+        port = int(fqdn_components[1])
+        if not 0 < port <= 65535:
+            raise ValueError(f"Port {port} is not in the valid range (1-65535).")
+        return value
+    return valid_domain_with_wildcard(value)
+
+
 @dataclass(frozen=True)
 class BackendState:
     """Charm state subset that contains the backend configuration.
@@ -217,12 +239,12 @@ class State:
     timeout: Timeout
     service: str = Field(..., min_length=1)
     paths: list[Annotated[str, BeforeValidator(value_has_valid_characters)]] = Field(default=[])
-    hostname: Optional[Annotated[str, BeforeValidator(valid_domain_with_wildcard)]] = Field(
-        default=None
+    hostname: Optional[Annotated[str, BeforeValidator(valid_domain_with_wildcard_and_port)]] = (
+        Field(default=None)
     )
-    additional_hostnames: list[Annotated[str, BeforeValidator(valid_domain_with_wildcard)]] = (
-        Field(default=[])
-    )
+    additional_hostnames: list[
+        Annotated[str, BeforeValidator(valid_domain_with_wildcard_and_port)]
+    ] = Field(default=[])
     load_balancing_configuration: LoadBalancingConfiguration = Field(
         default=LoadBalancingConfiguration()
     )

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -402,6 +402,10 @@ def test_state_from_charm_invalid_additional_hostnames():
         pytest.param("example.com", id="standard_hostname"),
         pytest.param("subdomain.example.com", id="standard_subdomain"),
         pytest.param("a.b.c.d.example.com", id="multi_level_subdomain"),
+        pytest.param("example.com:443", id="hostname_with_port"),
+        pytest.param("*.example.com:443", id="wildcard_hostname_with_port"),
+        pytest.param("subdomain.example.com:8080", id="subdomain_with_port"),
+        pytest.param("*.subdomain.example.com:8443", id="wildcard_subdomain_with_port"),
     ],
 )
 def test_state_from_charm_valid_hostname_with_wildcard(hostname):
@@ -430,6 +434,13 @@ def test_state_from_charm_valid_hostname_with_wildcard(hostname):
         pytest.param("*.*.example.com", id="multiple_wildcards"),
         pytest.param("example.*.com", id="wildcard_in_middle"),
         pytest.param("*.com", id="wildcard_tld"),
+        pytest.param("*.com:443", id="wildcard_tld_with_port"),
+        pytest.param("**.example.com:443", id="double_wildcard_with_port"),
+        pytest.param("example.com:abc", id="non_numeric_port"),
+        pytest.param("example.com:", id="empty_port"),
+        pytest.param("example.com:0", id="port_zero"),
+        pytest.param("example.com:65536", id="port_out_of_range"),
+        pytest.param("*.example.com:-1", id="negative_port"),
     ],
 )
 def test_state_from_charm_invalid_hostname_wildcard(invalid_hostname):
@@ -455,6 +466,8 @@ def test_state_from_charm_invalid_hostname_wildcard(invalid_hostname):
         pytest.param("*.example.com,*.other.com", id="multiple_wildcards"),
         pytest.param("*.subdomain.example.com,normal.example.com", id="mixed_wildcard_standard"),
         pytest.param("example.com,subdomain.example.com", id="multiple_standard"),
+        pytest.param("example.com:443,other.com:8080", id="multiple_with_ports"),
+        pytest.param("*.example.com:443,normal.com", id="wildcard_with_port_and_standard"),
     ],
 )
 def test_state_from_charm_valid_additional_hostnames_with_wildcard(additional_hostnames):
@@ -480,6 +493,8 @@ def test_state_from_charm_valid_additional_hostnames_with_wildcard(additional_ho
         pytest.param("**.example.com", id="double_wildcard"),
         pytest.param("*example.com,valid.com", id="one_invalid_one_valid"),
         pytest.param("valid.com,*.*.example.com", id="valid_and_multiple_wildcards"),
+        pytest.param("*.com:443,valid.com", id="wildcard_tld_with_port_and_valid"),
+        pytest.param("valid.com,example.com:99999", id="valid_and_port_out_of_range"),
     ],
 )
 def test_state_from_charm_invalid_additional_hostnames_wildcard(invalid_additional_hostnames):


### PR DESCRIPTION
closes #118 

Following the discussion  in haproxy-operator https://github.com/canonical/haproxy-operator/issues/245 and https://github.com/canonical/haproxy-operator/issues/288, the haproxy ACL logic was updated to [strip out the port part and match only against the hostname part](https://github.com/canonical/haproxy-operator/blob/fee888c20bf9865d3c1ddc1ddab560c8f237a496/haproxy-operator/src/state/haproxy_route.py#L387)

This PR updates the validation logic of `ingress-configurator` to allow a port component ( an validates that the user set a valid port )

Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
