### PR TITLE
chore: migrate from self-hosted edge runner to GitHub-hosted runner

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -15,7 +15,6 @@ jobs:
       use-canonical-k8s: true
       provider: k8s
       juju-channel: 3/stable
-      self-hosted-runner: true
       charmcraft-channel: latest/edge
       modules: '["test_actions.py", "test_adapter.py", "test_integrator.py", "test_ingress_kubernetes.py", "test_haproxy_route_tcp.py"]'
       with-uv: true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,3 +11,4 @@ jobs:
       self-hosted-runner: false
       runs-on-base: ubuntu-24.04
       with-uv: true
+      python-version: "3.12"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,6 @@ jobs:
     uses: canonical/operator-workflows/.github/workflows/test.yaml@main
     secrets: inherit
     with:
-      self-hosted-runner: true
-      self-hosted-runner-label: "edge"
+      self-hosted-runner: false
+      runs-on-base: ubuntu-24.04
       with-uv: true


### PR DESCRIPTION
## Summary

This PR migrates unit and integration test workflows from the self-hosted `amd64-noble-medium-edge-ps7` ("edge") runner to GitHub-hosted `ubuntu-24.04` runners, which are free and unlimited for public repositories.

The `self-hosted-runner` and `self-hosted-runner-label` inputs are removed from the reusable workflow calls; the operator-workflows default then falls back to GitHub-hosted runners.