### PR TITLE
Add support for trust on k8s

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,4 +15,5 @@ resource "juju_application" "ingress-configurator" {
   config      = var.config
   constraints = var.constraints
   units       = var.units
+  trust       = var.trust
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,3 +47,9 @@ variable "units" {
   type        = number
   default     = 1
 }
+
+variable "trust" {
+  description = "Deploy with --trust (required for Kubernetes)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
The charm needs to be deployed with --trust on k8s.