### PR TITLE
ignore .worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ __pycache__/
 !.vale/styles/config/vocabularies/local
 # END VALE WORKFLOW IGNORE
 
+.worktrees/


### PR DESCRIPTION
Applicable spec: <link>

### Overview
ignore `.worktrees` commonly used for git worktrees

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
