### PR TITLE
fix: multiple gateway listeners to fix multiple routes with https (ISD-6028)

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -1,3 +1,4 @@
 configurator
 hostnames
 FQDNs
+HTTPRoute

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -12,7 +12,7 @@ Each revision is versioned by the date of the revision.
 
 ### Fixed
 
-- Fixed a bug where multiple `gateway-route` relations with enforced HTTPS caused the gateway to become unreachable. The fix creates one HTTPS HTTPRoute per hostname, each referencing its dedicated Gateway listener.
+- Fixed a bug where multiple `gateway-route` relations with enforced HTTPS caused the gateway to become unreachable. The fix creates one HTTPS HTTPRoute and one HTTP HTTPRoute per hostname, each referencing its dedicated Gateway listener.
 
 ### Added
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,10 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-06-26
 
+### Fixed
+
+- Fixed a bug where multiple `gateway-route` relations with enforced HTTPS caused the gateway to become unreachable. The fix creates one HTTPS HTTPRoute per hostname, each referencing its dedicated Gateway listener.
+
 ### Removed
 
 - Removed support for config-driven (external) backends with `gateway-route`, as the use case that originally motivated this feature no longer exists.

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -12,6 +12,29 @@ from pydantic import ValidationError
 logger = logging.getLogger()
 
 _K8S_RESOURCE_NAME_MAX_LENGTH = 63
+_GATEWAY_API_SECTION_NAME_MAX_LENGTH = 253
+
+
+def https_listener_name(gateway_name: str, hostname: str) -> str:
+    """Build the per-hostname HTTPS listener name / sectionName.
+
+    The name follows the convention ``{gateway_name}-https-{sanitized_hostname}``
+    where dots in the hostname are replaced with hyphens.  The result is capped at
+    253 characters (Gateway API SectionName limit).
+
+    This function must produce output **identical** to the equivalent helper in the
+    ``gateway-api-integrator`` provider so that the requirer's ``sectionName`` always
+    matches the provider's Gateway listener ``name``.
+
+    Args:
+        gateway_name: The name of the Gateway K8s resource.
+        hostname: The hostname for this listener.
+
+    Returns:
+        A listener name of at most 253 characters.
+    """
+    name = f"{gateway_name}-https-{hostname.replace('.', '-')}"
+    return name[:_GATEWAY_API_SECTION_NAME_MAX_LENGTH]
 
 
 def truncate_k8s_resource_name(name: str) -> str:

--- a/src/helpers.py
+++ b/src/helpers.py
@@ -12,29 +12,6 @@ from pydantic import ValidationError
 logger = logging.getLogger()
 
 _K8S_RESOURCE_NAME_MAX_LENGTH = 63
-_GATEWAY_API_SECTION_NAME_MAX_LENGTH = 253
-
-
-def https_listener_name(gateway_name: str, hostname: str) -> str:
-    """Build the per-hostname HTTPS listener name / sectionName.
-
-    The name follows the convention ``{gateway_name}-https-{sanitized_hostname}``
-    where dots in the hostname are replaced with hyphens.  The result is capped at
-    253 characters (Gateway API SectionName limit).
-
-    This function must produce output **identical** to the equivalent helper in the
-    ``gateway-api-integrator`` provider so that the requirer's ``sectionName`` always
-    matches the provider's Gateway listener ``name``.
-
-    Args:
-        gateway_name: The name of the Gateway K8s resource.
-        hostname: The hostname for this listener.
-
-    Returns:
-        A listener name of at most 253 characters.
-    """
-    name = f"{gateway_name}-https-{hostname.replace('.', '-')}"
-    return name[:_GATEWAY_API_SECTION_NAME_MAX_LENGTH]
 
 
 def truncate_k8s_resource_name(name: str) -> str:

--- a/src/http_route.py
+++ b/src/http_route.py
@@ -13,7 +13,7 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube.resources.discovery_v1 import EndpointSlice
 
-from helpers import https_listener_name, truncate_k8s_resource_name
+from helpers import truncate_k8s_resource_name
 from kubernetes import InvalidKubernetesPermissionError
 
 logger = logging.getLogger(__name__)
@@ -337,7 +337,7 @@ def create_http_routes(
                 scheme="https",
                 gateway_name=gateway_name,
                 gateway_namespace=gateway_model,
-                listener_name=https_listener_name(gateway_name, hostname),
+                listener_name=f"{gateway_name}-https-{hostname.replace('.', '-')}",
                 hostnames=[hostname],
                 paths=paths,
                 backend_service_name=backend_service_name,

--- a/src/http_route.py
+++ b/src/http_route.py
@@ -13,7 +13,7 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from lightkube.resources.discovery_v1 import EndpointSlice
 
-from helpers import truncate_k8s_resource_name
+from helpers import https_listener_name, truncate_k8s_resource_name
 from kubernetes import InvalidKubernetesPermissionError
 
 logger = logging.getLogger(__name__)
@@ -313,23 +313,37 @@ def create_http_routes(
     """
     managed_names = []
 
-    route_specs: list[str] = ["http"]
-    if https_mode in ("enabled", "enforced"):
-        route_specs.append("https")
+    # HTTP route (including redirect for enforced mode) covers all hostnames and
+    # targets the single hostname-less HTTP listener.
+    http_config = HTTPRouteConfig(
+        app_name=app_name,
+        scheme="http",
+        gateway_name=gateway_name,
+        gateway_namespace=gateway_model,
+        listener_name=f"{gateway_name}-http",
+        hostnames=hostnames,
+        paths=paths,
+        backend_service_name=backend_service_name,
+        backend_service_port=backend_service_port,
+        redirect_https=https_mode == "enforced",
+    )
+    managed_names.append(http_route_manager.apply(http_config))
 
-    for scheme in route_specs:
-        config = HTTPRouteConfig(
-            app_name=app_name,
-            scheme=scheme,
-            gateway_name=gateway_name,
-            gateway_namespace=gateway_model,
-            listener_name=f"{gateway_name}-{scheme}",
-            hostnames=hostnames,
-            paths=paths,
-            backend_service_name=backend_service_name,
-            backend_service_port=backend_service_port,
-            redirect_https=https_mode == "enforced" and scheme == "http",
-        )
-        managed_names.append(http_route_manager.apply(config))
+    # HTTPS routes: one per hostname, each targeting its own per-hostname listener.
+    if https_mode in ("enabled", "enforced"):
+        for hostname in hostnames:
+            https_config = HTTPRouteConfig(
+                app_name=app_name,
+                scheme="https",
+                gateway_name=gateway_name,
+                gateway_namespace=gateway_model,
+                listener_name=https_listener_name(gateway_name, hostname),
+                hostnames=[hostname],
+                paths=paths,
+                backend_service_name=backend_service_name,
+                backend_service_port=backend_service_port,
+                redirect_https=False,
+            )
+            managed_names.append(http_route_manager.apply(https_config))
 
     http_route_manager.delete_stale(exclude=managed_names)

--- a/src/http_route.py
+++ b/src/http_route.py
@@ -29,6 +29,40 @@ HTTPRouteResource = create_namespaced_resource(
 )
 
 
+def http_listener_name(gateway_name: str, hostname: str) -> str:
+    """Build the per-hostname HTTP listener name / sectionName.
+
+    The name follows the convention ``{gateway_name}-http-{sanitized_hostname}``
+    where dots in the hostname are replaced with hyphens. This mirrors the
+    gateway-api-integrator's HTTP listener naming so HTTPRoutes reference the
+    correct per-hostname listener.
+
+    Args:
+        gateway_name: The name of the Gateway K8s resource.
+        hostname: The hostname for this listener.
+
+    Returns:
+        The listener name.
+    """
+    return f"{gateway_name}-http-{hostname.replace('.', '-')}"
+
+
+def https_listener_name(gateway_name: str, hostname: str) -> str:
+    """Build the per-hostname HTTPS listener name / sectionName.
+
+    The name follows the convention ``{gateway_name}-https-{sanitized_hostname}``
+    where dots in the hostname are replaced with hyphens.
+
+    Args:
+        gateway_name: The name of the Gateway K8s resource.
+        hostname: The hostname for this listener.
+
+    Returns:
+        The listener name.
+    """
+    return f"{gateway_name}-https-{hostname.replace('.', '-')}"
+
+
 def ensure_workload_backend_service(
     client: Client,
     namespace: str,
@@ -129,7 +163,8 @@ class HTTPRouteConfig:
         scheme: The scheme of the HTTPRoute ("http" or "https").
         gateway_name: parentRef gateway name.
         gateway_namespace: parentRef namespace.
-        listener_name: sectionName (e.g. "<gateway_name>-http").
+        listener_names: List of sectionNames this route attaches to (e.g.
+            per-hostname HTTP listener names, or a single HTTPS listener name).
         hostnames: List of hostnames for the HTTPRoute.
         paths: List of path prefixes.
         backend_service_name: The workload K8s Service name.
@@ -141,7 +176,7 @@ class HTTPRouteConfig:
     scheme: str
     gateway_name: str
     gateway_namespace: str
-    listener_name: str
+    listener_names: list[str]
     hostnames: list[str]
     paths: list[str]
     backend_service_name: str
@@ -180,11 +215,14 @@ class HTTPRouteManager:
         Returns:
             A dict representing the HTTPRoute spec.
         """
-        parent_ref: dict[str, str] = {
-            "name": config.gateway_name,
-            "namespace": config.gateway_namespace,
-            "sectionName": config.listener_name,
-        }
+        parent_refs: list[dict[str, str]] = [
+            {
+                "name": config.gateway_name,
+                "namespace": config.gateway_namespace,
+                "sectionName": listener_name,
+            }
+            for listener_name in config.listener_names
+        ]
 
         if config.redirect_https:
             rules: list[dict[str, object]] = [
@@ -216,7 +254,7 @@ class HTTPRouteManager:
             ]
 
         spec: dict = {
-            "parentRefs": [parent_ref],
+            "parentRefs": parent_refs,
             "rules": rules,
         }
         if config.hostnames:
@@ -313,14 +351,23 @@ def create_http_routes(
     """
     managed_names = []
 
-    # HTTP route (including redirect for enforced mode) covers all hostnames and
-    # targets the single hostname-less HTTP listener.
+    # HTTP route: a single route covering all hostnames, attaching to every
+    # per-hostname HTTP listener via multiple parentRefs. When there are no
+    # hostnames, fall back to the single hostname-less HTTP listener (mirrors
+    # the gateway-api-integrator's empty-hostnames listener fallback).
+    if hostnames:
+        http_listener_names = [
+            http_listener_name(gateway_name, hostname) for hostname in hostnames
+        ]
+    else:
+        http_listener_names = [f"{gateway_name}-http"]
+
     http_config = HTTPRouteConfig(
         app_name=app_name,
         scheme="http",
         gateway_name=gateway_name,
         gateway_namespace=gateway_model,
-        listener_name=f"{gateway_name}-http",
+        listener_names=http_listener_names,
         hostnames=hostnames,
         paths=paths,
         backend_service_name=backend_service_name,
@@ -337,7 +384,7 @@ def create_http_routes(
                 scheme="https",
                 gateway_name=gateway_name,
                 gateway_namespace=gateway_model,
-                listener_name=f"{gateway_name}-https-{hostname.replace('.', '-')}",
+                listener_names=[https_listener_name(gateway_name, hostname)],
                 hostnames=[hostname],
                 paths=paths,
                 backend_service_name=backend_service_name,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -42,16 +42,16 @@ GATEWAY_CERTIFICATES_CHANNEL = "1/edge"
 
 # Closed-ports backend (flask-k8s, is_port_open=False).
 # Also reused by the enforced-HTTPS test, which runs in a separate model.
-GATEWAY_CONFIGURATOR_CLOSED = "configurator-closed"
-GATEWAY_BACKEND_CLOSED = "backend-closed"
-HOSTNAME_CLOSED = "closed.gateway.internal"
-ADDITIONAL_HOSTNAME_CLOSED = "alt-closed.gateway.internal"
+GATEWAY_CONFIGURATOR_CLOSED_PORTS = "configurator-closed"
+GATEWAY_BACKEND_CLOSED_PORTS = "backend-closed"
+HOSTNAME_BACKEND_CLOSED_PORTS = "closed.gateway.internal"
+ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS = "alt-closed.gateway.internal"
 
 # Open-ports backend (any-charm-k8s, is_port_open=True).
-GATEWAY_CONFIGURATOR_OPEN = "configurator-open"
-GATEWAY_BACKEND_OPEN = "backend-open"
-HOSTNAME_OPEN = "open.gateway.internal"
-ADDITIONAL_HOSTNAME_OPEN = "alt-open.gateway.internal"
+GATEWAY_CONFIGURATOR_OPEN_PORTS = "configurator-open"
+GATEWAY_BACKEND_OPEN_PORTS = "backend-open"
+HOSTNAME_BACKEND_OPEN_PORTS = "open.gateway.internal"
+ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS = "alt-open.gateway.internal"
 INGRESS_BACKEND_PORT = 8000
 GATEWAY_BACKEND_OPEN_PATH = "/api/v1"
 GATEWAY_BACKEND_OPEN_BODY = "ok from open-ports backend"
@@ -412,8 +412,8 @@ def backend_closed_fixture(juju_k8s: jubilant.Juju) -> str:
     Returns:
         The deployed application name.
     """
-    juju_k8s.deploy(charm="flask-k8s", app=GATEWAY_BACKEND_CLOSED, channel="latest/edge")
-    return GATEWAY_BACKEND_CLOSED
+    juju_k8s.deploy(charm="flask-k8s", app=GATEWAY_BACKEND_CLOSED_PORTS, channel="latest/edge")
+    return GATEWAY_BACKEND_CLOSED_PORTS
 
 
 @pytest.fixture(scope="module", name="backend_open")
@@ -434,7 +434,7 @@ def backend_open_fixture(juju_k8s: jubilant.Juju) -> str:
     juju_k8s.deploy(
         charm="any-charm-k8s",
         channel="beta",
-        app=GATEWAY_BACKEND_OPEN,
+        app=GATEWAY_BACKEND_OPEN_PORTS,
         config={
             "src-overwrite": json.dumps(
                 {
@@ -451,4 +451,4 @@ def backend_open_fixture(juju_k8s: jubilant.Juju) -> str:
             "python-packages": "\n".join(["pydantic", "charmlibs-apt"]),
         },
     )
-    return GATEWAY_BACKEND_OPEN
+    return GATEWAY_BACKEND_OPEN_PORTS

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,7 +34,7 @@ APP_NAME = "ingress-configurator"
 # Gateway-route (Kubernetes Gateway API) test configuration.
 GATEWAY_API_INTEGRATOR_APP_NAME = "gateway-api-integrator"
 GATEWAY_API_INTEGRATOR_CHANNEL = "1/edge"
-GATEWAY_API_INTEGRATOR_REVISION = 160
+GATEWAY_API_INTEGRATOR_REVISION = 163
 # GatewayClass provided by the Canonical Kubernetes used in CI.
 GATEWAY_CLASS = "ck-gateway"
 EXTERNAL_HOSTNAME = "gateway.internal"

--- a/tests/integration/helper.py
+++ b/tests/integration/helper.py
@@ -42,7 +42,7 @@ def get_gateway_address(juju: jubilant.Juju, gateway_api_integrator: str) -> str
     retry=retry_if_exception_type((AssertionError, requests.exceptions.RequestException)),
     reraise=True,
 )
-def wait_for_gateway_response(
+def assert_gateway_response(
     gateway_address: str,
     hostname: str | None,
     path: str,

--- a/tests/integration/test_gateway_route.py
+++ b/tests/integration/test_gateway_route.py
@@ -7,8 +7,8 @@ A headline goal of the gateway-api redesign is supporting multiple ``gateway-rou
 a single gateway-api-integrator, with one ingress-configurator per relation. This test proves
 that by deploying two ingress-configurator instances against the same gateway at once:
 
-    flask-k8s (closed)   ──ingress──▶  configurator-closed  ─┐  gateway-route
-    any-charm-k8s (open) ──ingress──▶  configurator-open    ─┘──────────────▶ gateway-api-integrator
+    flask-k8s (backendclosed-ports)   ──ingress──▶  configurator-closed  ─┐  gateway-route
+    any-charm-k8s (backend-open-ports) ──ingress──▶  configurator-open    ─┘──────────────▶ gateway-api-integrator
                                                                                        │
                                                                                Gateway + HTTPRoutes
                                                                                (one LoadBalancer address)
@@ -27,14 +27,14 @@ import jubilant
 import pytest
 
 from .conftest import (
-    ADDITIONAL_HOSTNAME_CLOSED,
-    ADDITIONAL_HOSTNAME_OPEN,
+    ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS,
+    ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS,
     GATEWAY_BACKEND_OPEN_BODY,
     GATEWAY_BACKEND_OPEN_PATH,
-    GATEWAY_CONFIGURATOR_CLOSED,
-    GATEWAY_CONFIGURATOR_OPEN,
-    HOSTNAME_CLOSED,
-    HOSTNAME_OPEN,
+    GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+    GATEWAY_CONFIGURATOR_OPEN_PORTS,
+    HOSTNAME_BACKEND_CLOSED_PORTS,
+    HOSTNAME_BACKEND_OPEN_PORTS,
     INGRESS_BACKEND_PORT,
     deploy_ingress_configurator_for_gateway_route,
 )
@@ -90,33 +90,33 @@ def multi_relation_gateway_stack_fixture(
     deploy_ingress_configurator_for_gateway_route(
         juju_k8s,
         charm,
-        GATEWAY_CONFIGURATOR_CLOSED,
+        GATEWAY_CONFIGURATOR_CLOSED_PORTS,
         gateway_api_integrator,
         config={
-            "hostname": HOSTNAME_CLOSED,
-            "additional-hostnames": ADDITIONAL_HOSTNAME_CLOSED,
+            "hostname": HOSTNAME_BACKEND_CLOSED_PORTS,
+            "additional-hostnames": ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS,
             "paths": BACKEND_PATH,
         },
     )
     deploy_ingress_configurator_for_gateway_route(
         juju_k8s,
         charm,
-        GATEWAY_CONFIGURATOR_OPEN,
+        GATEWAY_CONFIGURATOR_OPEN_PORTS,
         gateway_api_integrator,
         config={
-            "hostname": HOSTNAME_OPEN,
-            "additional-hostnames": ADDITIONAL_HOSTNAME_OPEN,
+            "hostname": HOSTNAME_BACKEND_OPEN_PORTS,
+            "additional-hostnames": ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS,
             "paths": BACKEND_PATH,
         },
     )
-    juju_k8s.integrate(f"{backend_closed}:ingress", f"{GATEWAY_CONFIGURATOR_CLOSED}:ingress")
-    juju_k8s.integrate(f"{backend_open}:ingress", f"{GATEWAY_CONFIGURATOR_OPEN}:ingress")
+    juju_k8s.integrate(f"{backend_closed}:ingress", f"{GATEWAY_CONFIGURATOR_CLOSED_PORTS}:ingress")
+    juju_k8s.integrate(f"{backend_open}:ingress", f"{GATEWAY_CONFIGURATOR_OPEN_PORTS}:ingress")
 
     # Wait for the whole stack to settle.
     all_apps = (
         gateway_api_integrator,
-        GATEWAY_CONFIGURATOR_CLOSED,
-        GATEWAY_CONFIGURATOR_OPEN,
+        GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+        GATEWAY_CONFIGURATOR_OPEN_PORTS,
         backend_closed,
         backend_open,
     )
@@ -129,8 +129,8 @@ def multi_relation_gateway_stack_fixture(
         gateway_api_integrator=gateway_api_integrator,
         backend_closed=backend_closed,
         backend_open=backend_open,
-        configurator_closed=GATEWAY_CONFIGURATOR_CLOSED,
-        configurator_open=GATEWAY_CONFIGURATOR_OPEN,
+        configurator_closed=GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+        configurator_open=GATEWAY_CONFIGURATOR_OPEN_PORTS,
     )
 
 
@@ -152,32 +152,49 @@ def test_gateway_route_multiple_relations(
     # The configurator creates a selector Service targeting the backend pod; no body assertion
     # since flask-k8s serves its own response.
     logger.info(
-        "checking closed-ports routing (%s, %s)", HOSTNAME_CLOSED, ADDITIONAL_HOSTNAME_CLOSED
+        "checking closed-ports routing (%s, %s)",
+        HOSTNAME_BACKEND_CLOSED_PORTS,
+        ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS,
     )
-    assert_gateway_response(gateway_address, HOSTNAME_CLOSED, BACKEND_PATH, expected_status=200)
-    assert_gateway_response(gateway_address, HOSTNAME_CLOSED, "/", expected_status=404)
     assert_gateway_response(
-        gateway_address, ADDITIONAL_HOSTNAME_CLOSED, BACKEND_PATH, expected_status=200
+        gateway_address, HOSTNAME_BACKEND_CLOSED_PORTS, BACKEND_PATH, expected_status=200
     )
-    assert_gateway_response(gateway_address, ADDITIONAL_HOSTNAME_CLOSED, "/", expected_status=404)
+    assert_gateway_response(
+        gateway_address, HOSTNAME_BACKEND_CLOSED_PORTS, "/", expected_status=404
+    )
+    assert_gateway_response(
+        gateway_address,
+        ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS,
+        BACKEND_PATH,
+        expected_status=200,
+    )
+    assert_gateway_response(
+        gateway_address, ADDITIONAL_HOSTNAME_BACKEND_CLOSED_PORTS, "/", expected_status=404
+    )
 
     # --- Open-ports adapter (any-charm-k8s, is_port_open=True) ---
     # The configurator routes directly to the pod IP; assert BACKEND_BODY to prove traffic
     # reaches this specific backend rather than any other 200 source.
-    logger.info("checking open-ports routing (%s, %s)", HOSTNAME_OPEN, ADDITIONAL_HOSTNAME_OPEN)
+    logger.info(
+        "checking open-ports routing (%s, %s)",
+        HOSTNAME_BACKEND_OPEN_PORTS,
+        ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS,
+    )
     assert_gateway_response(
         gateway_address,
-        HOSTNAME_OPEN,
+        HOSTNAME_BACKEND_OPEN_PORTS,
         BACKEND_PATH,
         expected_status=200,
         body_contains=BACKEND_BODY,
     )
-    assert_gateway_response(gateway_address, HOSTNAME_OPEN, "/", expected_status=404)
+    assert_gateway_response(gateway_address, HOSTNAME_BACKEND_OPEN_PORTS, "/", expected_status=404)
     assert_gateway_response(
         gateway_address,
-        ADDITIONAL_HOSTNAME_OPEN,
+        ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS,
         BACKEND_PATH,
         expected_status=200,
         body_contains=BACKEND_BODY,
     )
-    assert_gateway_response(gateway_address, ADDITIONAL_HOSTNAME_OPEN, "/", expected_status=404)
+    assert_gateway_response(
+        gateway_address, ADDITIONAL_HOSTNAME_BACKEND_OPEN_PORTS, "/", expected_status=404
+    )

--- a/tests/integration/test_gateway_route.py
+++ b/tests/integration/test_gateway_route.py
@@ -39,8 +39,8 @@ from .conftest import (
     deploy_ingress_configurator_for_gateway_route,
 )
 from .helper import (
+    assert_gateway_response,
     get_gateway_address,
-    wait_for_gateway_response,
 )
 
 logger = logging.getLogger(__name__)
@@ -154,32 +154,30 @@ def test_gateway_route_multiple_relations(
     logger.info(
         "checking closed-ports routing (%s, %s)", HOSTNAME_CLOSED, ADDITIONAL_HOSTNAME_CLOSED
     )
-    wait_for_gateway_response(gateway_address, HOSTNAME_CLOSED, BACKEND_PATH, expected_status=200)
-    wait_for_gateway_response(gateway_address, HOSTNAME_CLOSED, "/", expected_status=404)
-    wait_for_gateway_response(
+    assert_gateway_response(gateway_address, HOSTNAME_CLOSED, BACKEND_PATH, expected_status=200)
+    assert_gateway_response(gateway_address, HOSTNAME_CLOSED, "/", expected_status=404)
+    assert_gateway_response(
         gateway_address, ADDITIONAL_HOSTNAME_CLOSED, BACKEND_PATH, expected_status=200
     )
-    wait_for_gateway_response(
-        gateway_address, ADDITIONAL_HOSTNAME_CLOSED, "/", expected_status=404
-    )
+    assert_gateway_response(gateway_address, ADDITIONAL_HOSTNAME_CLOSED, "/", expected_status=404)
 
     # --- Open-ports adapter (any-charm-k8s, is_port_open=True) ---
     # The configurator routes directly to the pod IP; assert BACKEND_BODY to prove traffic
     # reaches this specific backend rather than any other 200 source.
     logger.info("checking open-ports routing (%s, %s)", HOSTNAME_OPEN, ADDITIONAL_HOSTNAME_OPEN)
-    wait_for_gateway_response(
+    assert_gateway_response(
         gateway_address,
         HOSTNAME_OPEN,
         BACKEND_PATH,
         expected_status=200,
         body_contains=BACKEND_BODY,
     )
-    wait_for_gateway_response(gateway_address, HOSTNAME_OPEN, "/", expected_status=404)
-    wait_for_gateway_response(
+    assert_gateway_response(gateway_address, HOSTNAME_OPEN, "/", expected_status=404)
+    assert_gateway_response(
         gateway_address,
         ADDITIONAL_HOSTNAME_OPEN,
         BACKEND_PATH,
         expected_status=200,
         body_contains=BACKEND_BODY,
     )
-    wait_for_gateway_response(gateway_address, ADDITIONAL_HOSTNAME_OPEN, "/", expected_status=404)
+    assert_gateway_response(gateway_address, ADDITIONAL_HOSTNAME_OPEN, "/", expected_status=404)

--- a/tests/integration/test_gateway_route_https.py
+++ b/tests/integration/test_gateway_route_https.py
@@ -37,7 +37,7 @@ from .conftest import (
     HOSTNAME_OPEN,
     deploy_ingress_configurator_for_gateway_route,
 )
-from .helper import get_gateway_address, wait_for_gateway_response
+from .helper import assert_gateway_response, get_gateway_address
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +147,7 @@ def test_gateway_route_https_enforced_multi_relation(
         logger.info("checking enforced-HTTPS routing for %s", hostname)
 
         # HTTP must issue a 301 redirect to HTTPS.
-        redirect = wait_for_gateway_response(
+        redirect = assert_gateway_response(
             gateway_address,
             hostname,
             "/",
@@ -161,7 +161,7 @@ def test_gateway_route_https_enforced_multi_relation(
         )
 
         # HTTPS must reach the backend (SNI carries the hostname; self-signed cert not verified).
-        wait_for_gateway_response(
+        assert_gateway_response(
             gateway_address,
             hostname,
             "/",

--- a/tests/integration/test_gateway_route_https.py
+++ b/tests/integration/test_gateway_route_https.py
@@ -7,11 +7,11 @@ Topology:
 
     self-signed-certificates ──certificates──▶ gateway-api-integrator (enforce-https=True)
                                                           ▲
-    flask-k8s (backend-closed)  ──ingress──▶ configurator-closed ─┤ gateway-route
-    any-charm-k8s (backend-open) ──ingress──▶ configurator-open  ─┘
+    flask-k8s (closed-ports)       ──ingress──▶ configurator-closed ─┤ gateway-route
+    any-charm-k8s (open-ports)    ──ingress──▶ configurator-open  ─┘
 
 The provider creates one per-hostname HTTPS Gateway listener per relation (one for
-``HOSTNAME_CLOSED``, one for ``HOSTNAME_OPEN``). Each listener has its own ``hostname``
+``HOSTNAME_CLOSED_PORTS``, one for ``HOSTNAME_OPEN_PORTS``). Each listener has its own ``hostname``
 field, so Cilium can assign a distinct SNI match to each Envoy filter chain, avoiding
 the "duplicate matcher" error that broke multi-relation HTTPS in the previous design.
 
@@ -31,10 +31,10 @@ import pytest
 from .conftest import (
     CERTIFICATES_APP_NAME,
     GATEWAY_CERTIFICATES_CHANNEL,
-    GATEWAY_CONFIGURATOR_CLOSED,
-    GATEWAY_CONFIGURATOR_OPEN,
-    HOSTNAME_CLOSED,
-    HOSTNAME_OPEN,
+    GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+    GATEWAY_CONFIGURATOR_OPEN_PORTS,
+    HOSTNAME_BACKEND_CLOSED_PORTS,
+    HOSTNAME_BACKEND_OPEN_PORTS,
     deploy_ingress_configurator_for_gateway_route,
 )
 from .helper import assert_gateway_response, get_gateway_address
@@ -84,25 +84,25 @@ def multi_relation_https_stack_fixture(
     deploy_ingress_configurator_for_gateway_route(
         juju_k8s,
         charm,
-        GATEWAY_CONFIGURATOR_CLOSED,
+        GATEWAY_CONFIGURATOR_CLOSED_PORTS,
         gateway_api_integrator,
-        config={"hostname": HOSTNAME_CLOSED},
+        config={"hostname": HOSTNAME_BACKEND_CLOSED_PORTS},
     )
     deploy_ingress_configurator_for_gateway_route(
         juju_k8s,
         charm,
-        GATEWAY_CONFIGURATOR_OPEN,
+        GATEWAY_CONFIGURATOR_OPEN_PORTS,
         gateway_api_integrator,
-        config={"hostname": HOSTNAME_OPEN},
+        config={"hostname": HOSTNAME_BACKEND_OPEN_PORTS},
     )
-    juju_k8s.integrate(f"{backend_closed}:ingress", f"{GATEWAY_CONFIGURATOR_CLOSED}:ingress")
-    juju_k8s.integrate(f"{backend_open}:ingress", f"{GATEWAY_CONFIGURATOR_OPEN}:ingress")
+    juju_k8s.integrate(f"{backend_closed}:ingress", f"{GATEWAY_CONFIGURATOR_CLOSED_PORTS}:ingress")
+    juju_k8s.integrate(f"{backend_open}:ingress", f"{GATEWAY_CONFIGURATOR_OPEN_PORTS}:ingress")
 
     all_apps = (
         gateway_api_integrator,
         CERTIFICATES_APP_NAME,
-        GATEWAY_CONFIGURATOR_CLOSED,
-        GATEWAY_CONFIGURATOR_OPEN,
+        GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+        GATEWAY_CONFIGURATOR_OPEN_PORTS,
         backend_closed,
         backend_open,
     )
@@ -115,8 +115,8 @@ def multi_relation_https_stack_fixture(
         gateway_api_integrator=gateway_api_integrator,
         backend_closed=backend_closed,
         backend_open=backend_open,
-        configurator_closed=GATEWAY_CONFIGURATOR_CLOSED,
-        configurator_open=GATEWAY_CONFIGURATOR_OPEN,
+        configurator_closed=GATEWAY_CONFIGURATOR_CLOSED_PORTS,
+        configurator_open=GATEWAY_CONFIGURATOR_OPEN_PORTS,
     )
 
 
@@ -143,7 +143,7 @@ def test_gateway_route_https_enforced_multi_relation(
     assert gateway_address, "gateway-api-integrator did not report a gateway address"
     logger.info("gateway address: %s", gateway_address)
 
-    for hostname in (HOSTNAME_CLOSED, HOSTNAME_OPEN):
+    for hostname in (HOSTNAME_BACKEND_CLOSED_PORTS, HOSTNAME_BACKEND_OPEN_PORTS):
         logger.info("checking enforced-HTTPS routing for %s", hostname)
 
         # HTTP must issue a 301 redirect to HTTPS.

--- a/tests/integration/test_gateway_route_https.py
+++ b/tests/integration/test_gateway_route_https.py
@@ -1,23 +1,29 @@
 # Copyright 2026 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""End-to-end integration test for gateway-route enforced HTTPS (TLS termination).
+"""End-to-end integration tests for gateway-route enforced HTTPS with multiple relations.
 
-Topology (single Kubernetes model):
+Topology:
 
     self-signed-certificates ──certificates──▶ gateway-api-integrator (enforce-https=True)
                                                           ▲
-    flask-k8s (backend) ──ingress──▶ ingress-configurator ┘ gateway-route
-                                                          │
-                                                  Gateway (HTTP + HTTPS listeners) + HTTPRoutes
+    flask-k8s (backend-closed)  ──ingress──▶ configurator-closed ─┤ gateway-route
+    any-charm-k8s (backend-open) ──ingress──▶ configurator-open  ─┘
 
-HTTPS/TLS termination itself is owned and already covered by gateway-api-integrator's own tests.
-What this test covers from the ingress-configurator side is this charm's enforced-mode HTTPRoute
-generation: when the provider reports ``https_mode=enforced`` ingress-configurator must create an
-HTTP route that issues a 301 redirect to HTTPS *and* an HTTPS route that reaches the backend.
+The provider creates one per-hostname HTTPS Gateway listener per relation (one for
+``HOSTNAME_CLOSED``, one for ``HOSTNAME_OPEN``). Each listener has its own ``hostname``
+field, so Cilium can assign a distinct SNI match to each Envoy filter chain, avoiding
+the "duplicate matcher" error that broke multi-relation HTTPS in the previous design.
+
+This module tests two things:
+1. **The regression**: with ≥ 2 HTTPS relations the gateway is reachable at all (not
+   NACKed by Envoy due to duplicate filter-chain matches).
+2. **Correct routing**: HTTP redirects to HTTPS and HTTPS reaches the backend for each
+   of the two distinct hostnames.
 """
 
 import logging
+from typing import NamedTuple
 
 import jubilant
 import pytest
@@ -26,7 +32,9 @@ from .conftest import (
     CERTIFICATES_APP_NAME,
     GATEWAY_CERTIFICATES_CHANNEL,
     GATEWAY_CONFIGURATOR_CLOSED,
+    GATEWAY_CONFIGURATOR_OPEN,
     HOSTNAME_CLOSED,
+    HOSTNAME_OPEN,
     deploy_ingress_configurator_for_gateway_route,
 )
 from .helper import get_gateway_address, wait_for_gateway_response
@@ -34,67 +42,129 @@ from .helper import get_gateway_address, wait_for_gateway_response
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.abort_on_fail
-def test_gateway_route_https_enforced(
+class HTTPSGatewayStack(NamedTuple):
+    """All deployed app names for the multi-relation enforced-HTTPS test."""
+
+    gateway_api_integrator: str
+    backend_closed: str
+    backend_open: str
+    configurator_closed: str
+    configurator_open: str
+
+
+@pytest.fixture(scope="module", name="multi_relation_https_stack")
+def multi_relation_https_stack_fixture(
     juju_k8s: jubilant.Juju,
     gateway_api_integrator: str,
     backend_closed: str,
+    backend_open: str,
     charm: str,
-):
-    """Enforced HTTPS: HTTP is redirected to HTTPS and the HTTPS route reaches the backend.
+) -> HTTPSGatewayStack:
+    """Deploy two ingress-configurators on one HTTPS gateway and wait for all Active.
+
+    Enables ``enforce-https`` on the shared gateway, relates it to a TLS provider, then
+    deploys one configurator per backend (closed-ports and open-ports) and wires their
+    ``ingress`` relations.
 
     Args:
         juju_k8s: Jubilant Juju instance for the Kubernetes model.
-        gateway_api_integrator: gateway-api-integrator (gateway-route provider) app name.
-        backend_closed: flask-k8s backend workload app name.
+        gateway_api_integrator: Shared gateway-route provider app name.
+        backend_closed: flask-k8s backend (is_port_open=False).
+        backend_open: any-charm-k8s backend (is_port_open=True).
         charm: Path to the packed ingress-configurator charm.
+
+    Returns:
+        Named tuple with all deployed app names.
     """
-    # Enforce HTTPS, relate the gateway to a TLS provider, and wire the configurator to the backend.
     juju_k8s.config(gateway_api_integrator, {"enforce-https": True})
     juju_k8s.deploy(charm=CERTIFICATES_APP_NAME, channel=GATEWAY_CERTIFICATES_CHANNEL)
-    deploy_ingress_configurator_for_gateway_route(
-        juju_k8s, charm, GATEWAY_CONFIGURATOR_CLOSED, gateway_api_integrator
-    )
     juju_k8s.integrate(
         f"{CERTIFICATES_APP_NAME}:certificates", f"{gateway_api_integrator}:certificates"
     )
+    deploy_ingress_configurator_for_gateway_route(
+        juju_k8s,
+        charm,
+        GATEWAY_CONFIGURATOR_CLOSED,
+        gateway_api_integrator,
+        config={"hostname": HOSTNAME_CLOSED},
+    )
+    deploy_ingress_configurator_for_gateway_route(
+        juju_k8s,
+        charm,
+        GATEWAY_CONFIGURATOR_OPEN,
+        gateway_api_integrator,
+        config={"hostname": HOSTNAME_OPEN},
+    )
     juju_k8s.integrate(f"{backend_closed}:ingress", f"{GATEWAY_CONFIGURATOR_CLOSED}:ingress")
-    juju_k8s.config(GATEWAY_CONFIGURATOR_CLOSED, {"hostname": HOSTNAME_CLOSED})
+    juju_k8s.integrate(f"{backend_open}:ingress", f"{GATEWAY_CONFIGURATOR_OPEN}:ingress")
 
+    all_apps = (
+        gateway_api_integrator,
+        CERTIFICATES_APP_NAME,
+        GATEWAY_CONFIGURATOR_CLOSED,
+        GATEWAY_CONFIGURATOR_OPEN,
+        backend_closed,
+        backend_open,
+    )
     juju_k8s.wait(
-        lambda status: jubilant.all_active(
-            status,
-            gateway_api_integrator,
-            CERTIFICATES_APP_NAME,
-            GATEWAY_CONFIGURATOR_CLOSED,
-            backend_closed,
-        ),
+        lambda status: jubilant.all_active(status, *all_apps),
         error=jubilant.any_error,
     )
 
-    gateway_address = get_gateway_address(juju_k8s, gateway_api_integrator)
+    return HTTPSGatewayStack(
+        gateway_api_integrator=gateway_api_integrator,
+        backend_closed=backend_closed,
+        backend_open=backend_open,
+        configurator_closed=GATEWAY_CONFIGURATOR_CLOSED,
+        configurator_open=GATEWAY_CONFIGURATOR_OPEN,
+    )
+
+
+@pytest.mark.abort_on_fail
+def test_gateway_route_https_enforced_multi_relation(
+    juju_k8s: jubilant.Juju,
+    multi_relation_https_stack: HTTPSGatewayStack,
+):
+    """Two HTTPS relations: HTTP redirects and HTTPS backend reach work for each hostname.
+
+    This is the regression test for the Cilium/Envoy duplicate filter-chain bug.  With the
+    old design (all certs on one hostname-less listener), Envoy NACKs the whole listener and
+    both :80 and :443 become unreachable.  With the fix (one listener per hostname, each
+    carrying its own ``hostname`` field), Envoy can distinguish chains by SNI and the gateway
+    remains reachable.
+
+    Args:
+        juju_k8s: Jubilant Juju instance for the Kubernetes model.
+        multi_relation_https_stack: Shared stack with gateway address and all app names.
+    """
+    gateway_address = get_gateway_address(
+        juju_k8s, multi_relation_https_stack.gateway_api_integrator
+    )
     assert gateway_address, "gateway-api-integrator did not report a gateway address"
     logger.info("gateway address: %s", gateway_address)
 
-    # HTTP is redirected to HTTPS (do not follow the redirect so the 301 and Location are visible).
-    redirect = wait_for_gateway_response(
-        gateway_address,
-        HOSTNAME_CLOSED,
-        "/",
-        scheme="http",
-        expected_status=301,
-        allow_redirects=False,
-    )
-    location = redirect.headers.get("location", "")
-    assert location.startswith("https://"), (
-        f"expected an HTTPS redirect Location, got {location!r}"
-    )
+    for hostname in (HOSTNAME_CLOSED, HOSTNAME_OPEN):
+        logger.info("checking enforced-HTTPS routing for %s", hostname)
 
-    # The HTTPS route reaches the backend (SNI carries the hostname; self-signed cert not verified).
-    wait_for_gateway_response(
-        gateway_address,
-        HOSTNAME_CLOSED,
-        "/",
-        scheme="https",
-        expected_status=200,
-    )
+        # HTTP must issue a 301 redirect to HTTPS.
+        redirect = wait_for_gateway_response(
+            gateway_address,
+            hostname,
+            "/",
+            scheme="http",
+            expected_status=301,
+            allow_redirects=False,
+        )
+        location = redirect.headers.get("location", "")
+        assert location.startswith("https://"), (
+            f"expected an HTTPS redirect Location for {hostname}, got {location!r}"
+        )
+
+        # HTTPS must reach the backend (SNI carries the hostname; self-signed cert not verified).
+        wait_for_gateway_response(
+            gateway_address,
+            hostname,
+            "/",
+            scheme="https",
+            expected_status=200,
+        )

--- a/tests/unit/test_gateway_route.py
+++ b/tests/unit/test_gateway_route.py
@@ -281,9 +281,9 @@ def test_gateway_route_https_mode_enforced(
     http_resource = http_call.args[0]
     https_resource = https_call.args[0]
 
-    # HTTP route: 301 redirect to HTTPS, http-listener
+    # HTTP route: 301 redirect to HTTPS, per-hostname http-listener
     assert http_resource.metadata.name == "ingress-configurator-testing-app-http"
-    assert http_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http"
+    assert http_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http-example-com"
     http_rule = http_resource.spec["rules"][0]
     assert http_rule["filters"][0]["type"] == "RequestRedirect"
     assert http_rule["filters"][0]["requestRedirect"]["scheme"] == "https"
@@ -366,7 +366,7 @@ def test_gateway_route_https_mode_disabled(
     resource = single_call.args[0]
 
     assert resource.metadata.name == "ingress-configurator-testing-app-http"
-    assert resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http"
+    assert resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http-example-com"
     rule = resource.spec["rules"][0]
     assert rule["backendRefs"][0]["port"] == 8080
     assert "filters" not in rule
@@ -411,7 +411,7 @@ def test_gateway_route_https_mode_enabled(
 
     # Both routes forward to the backend
     assert http_resource.metadata.name == "ingress-configurator-testing-app-http"
-    assert http_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http"
+    assert http_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-http-example-com"
     http_rule = http_resource.spec["rules"][0]
     assert http_rule["backendRefs"][0]["port"] == 8080
     assert "filters" not in http_rule

--- a/tests/unit/test_gateway_route.py
+++ b/tests/unit/test_gateway_route.py
@@ -290,9 +290,9 @@ def test_gateway_route_https_mode_enforced(
     assert http_rule["filters"][0]["requestRedirect"]["statusCode"] == 301
     assert "backendRefs" not in http_rule
 
-    # HTTPS route: forwards to backend, https-listener
+    # HTTPS route: forwards to backend, per-hostname https-listener
     assert https_resource.metadata.name == "ingress-configurator-testing-app-https"
-    assert https_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-https"
+    assert https_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-https-example-com"
     https_rule = https_resource.spec["rules"][0]
     assert https_rule["backendRefs"][0]["port"] == 8080
     assert "filters" not in https_rule
@@ -417,7 +417,7 @@ def test_gateway_route_https_mode_enabled(
     assert "filters" not in http_rule
 
     assert https_resource.metadata.name == "ingress-configurator-testing-app-https"
-    assert https_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-https"
+    assert https_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-https-example-com"
     https_rule = https_resource.spec["rules"][0]
     assert https_rule["backendRefs"][0]["port"] == 8080
     assert "filters" not in https_rule

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -10,6 +10,9 @@ from lightkube import ApiError
 
 from http_route import (
     MANAGED_BY_LABEL,
+    HTTPRouteConfig,
+    HTTPRouteManager,
+    create_http_routes,
     delete_backend_services_owned_by,
     ensure_workload_backend_service,
 )
@@ -222,3 +225,214 @@ def test_ensure_workload_backend_service_reraises_other_api_errors():
         ensure_workload_backend_service(
             client, "testing-model", "charm-my-app", "my-app", 8080, "charm"
         )
+
+
+# ---------------------------------------------------------------------------
+# create_http_routes tests
+# ---------------------------------------------------------------------------
+
+GW_NAME = "my-gateway"
+GW_MODEL = "my-model"
+BACKEND_SVC = "backend-svc"
+BACKEND_PORT = 8080
+APP_NAME = "my-app"
+PATHS = ["/"]
+
+
+def _make_http_route_manager() -> tuple[HTTPRouteManager, MagicMock]:
+    """Return an HTTPRouteManager backed by a MagicMock client.
+
+    The manager's ``apply`` method returns the resource_name argument passed to
+    HTTPRouteConfig so callers can inspect what was applied.
+    """
+    mock_client = MagicMock()
+
+    # apply() is called inside HTTPRouteManager.apply() — patch it so we capture
+    # the config objects rather than actually calling the K8s API.
+    applied: list[HTTPRouteConfig] = []
+
+    def _fake_apply(config: HTTPRouteConfig) -> str:
+        applied.append(config)
+        # Return a stable resource name so delete_stale() has something to exclude.
+        return f"{config.app_name}-{config.backend_service_name}-{config.scheme}"
+
+    manager = HTTPRouteManager(
+        client=mock_client,
+        namespace=GW_MODEL,
+        labels={MANAGED_BY_LABEL: APP_NAME},
+    )
+    manager.apply = _fake_apply  # type: ignore[method-assign]
+    manager.delete_stale = MagicMock()  # type: ignore[method-assign]
+    # Expose applied list through the mock for assertions
+    mock_client._applied = applied
+    return manager, mock_client
+
+
+def test_create_http_routes_http_only():
+    """
+    arrange: https_mode=disabled, two hostnames.
+    act: call create_http_routes.
+    assert: only one HTTP route is created targeting the single HTTP listener.
+    """
+    manager, mock = _make_http_route_manager()
+
+    create_http_routes(
+        manager,
+        APP_NAME,
+        GW_NAME,
+        GW_MODEL,
+        "disabled",
+        ["a.example.com", "b.example.com"],
+        PATHS,
+        BACKEND_SVC,
+        BACKEND_PORT,
+    )
+
+    applied = mock._applied
+    assert len(applied) == 1
+    assert applied[0].scheme == "http"
+    assert applied[0].listener_name == f"{GW_NAME}-http"
+    assert applied[0].redirect_https is False
+
+
+def test_create_http_routes_https_enabled_single_hostname():
+    """
+    arrange: https_mode=enabled, one hostname.
+    act: call create_http_routes.
+    assert: 2 routes created — 1 HTTP (all hostnames, no redirect) + 1 HTTPS (the hostname).
+    """
+    manager, mock = _make_http_route_manager()
+
+    create_http_routes(
+        manager,
+        APP_NAME,
+        GW_NAME,
+        GW_MODEL,
+        "enabled",
+        ["app.example.com"],
+        PATHS,
+        BACKEND_SVC,
+        BACKEND_PORT,
+    )
+
+    applied = mock._applied
+    assert len(applied) == 2
+
+    http_route = next(r for r in applied if r.scheme == "http")
+    https_route = next(r for r in applied if r.scheme == "https")
+
+    assert http_route.redirect_https is False
+    assert https_route.listener_name == f"{GW_NAME}-https-app-example-com"
+    assert https_route.hostnames == ["app.example.com"]
+
+
+def test_create_http_routes_https_enabled_multiple_hostnames():
+    """
+    arrange: https_mode=enabled, two hostnames.
+    act: call create_http_routes.
+    assert: 3 routes — 1 HTTP covering both hostnames + 2 HTTPS each covering one hostname
+        with its own per-hostname listener.
+    """
+    manager, mock = _make_http_route_manager()
+    hostnames = ["alpha.example.com", "beta.example.com"]
+
+    create_http_routes(
+        manager,
+        APP_NAME,
+        GW_NAME,
+        GW_MODEL,
+        "enabled",
+        hostnames,
+        PATHS,
+        BACKEND_SVC,
+        BACKEND_PORT,
+    )
+
+    applied = mock._applied
+    assert len(applied) == 3
+
+    http_routes = [r for r in applied if r.scheme == "http"]
+    https_routes = [r for r in applied if r.scheme == "https"]
+
+    assert len(http_routes) == 1
+    assert len(https_routes) == 2
+
+    # HTTP route covers all hostnames
+    assert set(http_routes[0].hostnames) == set(hostnames)
+
+    # Each HTTPS route targets exactly one hostname with its own listener
+    https_listener_names = {r.listener_name for r in https_routes}
+    assert https_listener_names == {
+        f"{GW_NAME}-https-alpha-example-com",
+        f"{GW_NAME}-https-beta-example-com",
+    }
+    https_hostname_sets = [set(r.hostnames) for r in https_routes]
+    assert {"alpha.example.com"} in https_hostname_sets
+    assert {"beta.example.com"} in https_hostname_sets
+
+    for r in https_routes:
+        assert r.redirect_https is False
+
+
+def test_create_http_routes_https_enforced_multiple_hostnames():
+    """
+    arrange: https_mode=enforced, two hostnames.
+    act: call create_http_routes.
+    assert: 3 routes — 1 HTTP redirect (all hostnames) + 2 HTTPS per hostname.
+        The HTTP route has redirect_https=True; HTTPS routes have redirect_https=False.
+    """
+    manager, mock = _make_http_route_manager()
+    hostnames = ["alpha.example.com", "beta.example.com"]
+
+    create_http_routes(
+        manager,
+        APP_NAME,
+        GW_NAME,
+        GW_MODEL,
+        "enforced",
+        hostnames,
+        PATHS,
+        BACKEND_SVC,
+        BACKEND_PORT,
+    )
+
+    applied = mock._applied
+    assert len(applied) == 3
+
+    http_routes = [r for r in applied if r.scheme == "http"]
+    https_routes = [r for r in applied if r.scheme == "https"]
+
+    assert len(http_routes) == 1
+    assert len(https_routes) == 2
+
+    assert http_routes[0].redirect_https is True
+    assert set(http_routes[0].hostnames) == set(hostnames)
+
+    for r in https_routes:
+        assert r.redirect_https is False
+        assert len(r.hostnames) == 1
+
+
+def test_create_http_routes_empty_hostnames():
+    """
+    arrange: https_mode=enabled but hostnames=[].
+    act: call create_http_routes.
+    assert: only 1 HTTP route is created (no HTTPS routes when there are no hostnames).
+    """
+    manager, mock = _make_http_route_manager()
+
+    create_http_routes(
+        manager,
+        APP_NAME,
+        GW_NAME,
+        GW_MODEL,
+        "enabled",
+        [],
+        PATHS,
+        BACKEND_SVC,
+        BACKEND_PORT,
+    )
+
+    applied = mock._applied
+    assert len(applied) == 1
+    assert applied[0].scheme == "http"

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -272,7 +272,7 @@ def test_create_http_routes_http_only():
     """
     arrange: https_mode=disabled, two hostnames.
     act: call create_http_routes.
-    assert: only one HTTP route is created targeting the single HTTP listener.
+    assert: a single HTTP route covering both hostnames, attaching to both per-hostname HTTP listeners.
     """
     manager, mock = _make_http_route_manager()
 
@@ -291,8 +291,12 @@ def test_create_http_routes_http_only():
     applied = mock._applied
     assert len(applied) == 1
     assert applied[0].scheme == "http"
-    assert applied[0].listener_name == f"{GW_NAME}-http"
     assert applied[0].redirect_https is False
+    assert set(applied[0].hostnames) == {"a.example.com", "b.example.com"}
+    assert set(applied[0].listener_names) == {
+        f"{GW_NAME}-http-a-example-com",
+        f"{GW_NAME}-http-b-example-com",
+    }
 
 
 def test_create_http_routes_https_enabled_single_hostname():
@@ -322,7 +326,9 @@ def test_create_http_routes_https_enabled_single_hostname():
     https_route = next(r for r in applied if r.scheme == "https")
 
     assert http_route.redirect_https is False
-    assert https_route.listener_name == f"{GW_NAME}-https-app-example-com"
+    assert http_route.listener_names == [f"{GW_NAME}-http-app-example-com"]
+    assert http_route.hostnames == ["app.example.com"]
+    assert https_route.listener_names == [f"{GW_NAME}-https-app-example-com"]
     assert https_route.hostnames == ["app.example.com"]
 
 
@@ -330,8 +336,8 @@ def test_create_http_routes_https_enabled_multiple_hostnames():
     """
     arrange: https_mode=enabled, two hostnames.
     act: call create_http_routes.
-    assert: 3 routes — 1 HTTP covering both hostnames + 2 HTTPS each covering one hostname
-        with its own per-hostname listener.
+    assert: 3 routes — 1 HTTP covering both hostnames (attaching to both HTTP listeners)
+        + 2 HTTPS each covering one hostname with its own per-hostname listener.
     """
     manager, mock = _make_http_route_manager()
     hostnames = ["alpha.example.com", "beta.example.com"]
@@ -357,11 +363,15 @@ def test_create_http_routes_https_enabled_multiple_hostnames():
     assert len(http_routes) == 1
     assert len(https_routes) == 2
 
-    # HTTP route covers all hostnames
+    # HTTP route covers all hostnames and attaches to both per-hostname HTTP listeners
     assert set(http_routes[0].hostnames) == set(hostnames)
+    assert set(http_routes[0].listener_names) == {
+        f"{GW_NAME}-http-alpha-example-com",
+        f"{GW_NAME}-http-beta-example-com",
+    }
 
     # Each HTTPS route targets exactly one hostname with its own listener
-    https_listener_names = {r.listener_name for r in https_routes}
+    https_listener_names = {r.listener_names[0] for r in https_routes}
     assert https_listener_names == {
         f"{GW_NAME}-https-alpha-example-com",
         f"{GW_NAME}-https-beta-example-com",
@@ -370,7 +380,7 @@ def test_create_http_routes_https_enabled_multiple_hostnames():
     assert {"alpha.example.com"} in https_hostname_sets
     assert {"beta.example.com"} in https_hostname_sets
 
-    for r in https_routes:
+    for r in http_routes + https_routes:
         assert r.redirect_https is False
 
 
@@ -417,7 +427,8 @@ def test_create_http_routes_empty_hostnames():
     """
     arrange: https_mode=enabled but hostnames=[].
     act: call create_http_routes.
-    assert: only 1 HTTP route is created (no HTTPS routes when there are no hostnames).
+    assert: only 1 HTTP route is created targeting the hostname-less HTTP listener
+        (no HTTPS routes when there are no hostnames).
     """
     manager, mock = _make_http_route_manager()
 
@@ -436,3 +447,4 @@ def test_create_http_routes_empty_hostnames():
     applied = mock._applied
     assert len(applied) == 1
     assert applied[0].scheme == "http"
+    assert applied[0].listener_names == [f"{GW_NAME}-http"]


### PR DESCRIPTION
Applicable spec: <link>

### Overview

Problem: create_http_routes created one HTTPS HTTPRoute covering all hostnames, pointing sectionName at the old single {gateway_name}-https listener. With the provider now emitting per-hostname listeners, the requirer must match.

Fix: Split HTTPS route creation — one HTTPRoute per hostname, each with sectionName = {gateway_name}-https-{sanitized_hostname} and hostnames: [hostname], matching exactly one Gateway listener. The HTTP route (including redirect in enforced mode) remains a single route covering all hostnames and targeting the unchanged {gateway_name}-http listener.
### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
