### PR TITLE
Update juju provider version constraints

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-20
+
+- Updated terraform module to allow deploying `ingress-configurator` with Juju provider 2.x.
+
 ## 2026-06-26
 
 ### Fixed

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@ Each revision is versioned by the date of the revision.
 
 ## 2026-07-20
 
+### Updated
+
 - Updated terraform module to allow deploying `ingress-configurator` with Juju provider 2.x.
 
 ## 2026-06-26

--- a/terraform/tests/setup/main.tf
+++ b/terraform/tests/setup/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_version = "~> 1.12"
   required_providers {
     juju = {
-      version = "~> 1.0"
+      version = ">= 1.0, < 3.0"
       source  = "juju/juju"
     }
   }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -6,7 +6,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 1.0"
+      version = ">= 1.0, < 3.0"
     }
   }
 }


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Allow ingress configurator to be deployed using Juju provider 2.0

### Rationale

<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [ ] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [ ] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [ ] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
