### PR TITLE
feat: use hsts in responses (ISD-6121)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Each revision is versioned by the date of the revision.
 
+## 2026-07-20
+
+### Added
+
+- Added support for the `Strict-Transport-Security` (HSTS) response header on HTTPS `HTTPRoute`s.
+When HTTPS is enforced, the `hsts_max_age` value published by `gateway-api-integrator`
+is injected as an HSTS header via a `ResponseHeaderModifier` filter.
+
 ## 2026-06-26
 
 ### Fixed

--- a/lib/charms/gateway_api_integrator/v1/gateway_route.py
+++ b/lib/charms/gateway_api_integrator/v1/gateway_route.py
@@ -119,8 +119,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
-
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 GATEWAY_ROUTE_RELATION_NAME = "gateway-route"
@@ -194,6 +193,8 @@ class GatewayRouteProviderAppData:
         https_mode: The HTTPS mode indicating how the provider handles TLS.
         gateway_address: The gateway LB address. Provided so requirers without a
             configured hostname can reference the gateway by IP.
+        hsts_max_age: The max-age value for the Strict-Transport-Security header.
+            Set only when HTTPS is enforced; None otherwise.
     """
 
     gateway_name: str = Field(description="The name of the Gateway resource.")
@@ -204,6 +205,11 @@ class GatewayRouteProviderAppData:
     gateway_address: str | None = Field(
         description="The gateway LB address, used when no hostname is configured.",
         default=None,
+    )
+    hsts_max_age: int | None = Field(
+        description="The max-age for the Strict-Transport-Security header, set only when enforced.",
+        default=None,
+        ge=0,
     )
 
 
@@ -264,6 +270,7 @@ class GatewayRouteProvider(Object):
         gateway_model: str,
         https_mode: HttpsMode,
         gateway_address: str | None = None,
+        hsts_max_age: int | None = None,
     ) -> None:
         """Publish gateway information to requirers with valid data.
 
@@ -274,6 +281,8 @@ class GatewayRouteProvider(Object):
             gateway_model: The Juju model (K8s namespace) of the Gateway resource.
             https_mode: The HTTPS mode for the gateway.
             gateway_address: The gateway LB address, used when no hostname is configured.
+            hsts_max_age: The max-age for the Strict-Transport-Security header. Should
+                only be set when HTTPS is enforced; None otherwise.
 
         Raises:
             GatewayRouteInvalidRelationDataError: When publishing fails for any relation.
@@ -289,6 +298,7 @@ class GatewayRouteProvider(Object):
                     gateway_model=gateway_model,
                     https_mode=https_mode,
                     gateway_address=gateway_address,
+                    hsts_max_age=hsts_max_age,
                 )
                 relation.save(app_data, self.charm.app)
             except (ValidationError, RelationDataTypeError):

--- a/src/charm.py
+++ b/src/charm.py
@@ -439,6 +439,7 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 if selector_svc_name
                 else state.application_name,
                 backend_service_port=state.backend_port,
+                hsts_max_age=provider_data.hsts_max_age,
             )
         except InvalidKubernetesPermissionError as exc:
             logger.exception("Kubernetes API permission error: %s", exc)

--- a/src/http_route.py
+++ b/src/http_route.py
@@ -259,7 +259,7 @@ class HTTPRouteManager:
                     {
                         "type": "ResponseHeaderModifier",
                         "responseHeaderModifier": {
-                            "add": [
+                            "set": [
                                 {
                                     "name": "Strict-Transport-Security",
                                     "value": f"max-age={config.hsts_max_age}",
@@ -412,7 +412,7 @@ def create_http_routes(
                 backend_service_name=backend_service_name,
                 backend_service_port=backend_service_port,
                 redirect_https=False,
-                hsts_max_age=hsts_max_age,
+                hsts_max_age=hsts_max_age if https_mode == "enforced" else None,
             )
             managed_names.append(http_route_manager.apply(https_config))
 

--- a/src/http_route.py
+++ b/src/http_route.py
@@ -170,6 +170,9 @@ class HTTPRouteConfig:
         backend_service_name: The workload K8s Service name.
         backend_service_port: The workload port.
         redirect_https: If True, this route issues a 301 HTTPS redirect.
+        hsts_max_age: When set, inject a ``Strict-Transport-Security`` response
+            header with this ``max-age`` value. ``None`` means no HSTS header.
+            ``0`` instructs browsers to clear any cached HSTS policy.
     """
 
     app_name: str
@@ -182,6 +185,7 @@ class HTTPRouteConfig:
     backend_service_name: str
     backend_service_port: int
     redirect_https: bool = False
+    hsts_max_age: int | None = None
 
 
 class HTTPRouteManager:
@@ -239,19 +243,32 @@ class HTTPRouteManager:
                 }
             ]
         else:
-            rules = [
-                {
-                    "matches": [
-                        {"path": {"type": "PathPrefix", "value": path}} for path in config.paths
-                    ],
-                    "backendRefs": [
-                        {
-                            "name": config.backend_service_name,
-                            "port": config.backend_service_port,
-                        }
-                    ],
-                }
-            ]
+            rule: dict[str, object] = {
+                "matches": [
+                    {"path": {"type": "PathPrefix", "value": path}} for path in config.paths
+                ],
+                "backendRefs": [
+                    {
+                        "name": config.backend_service_name,
+                        "port": config.backend_service_port,
+                    }
+                ],
+            }
+            if config.hsts_max_age is not None:
+                rule["filters"] = [
+                    {
+                        "type": "ResponseHeaderModifier",
+                        "responseHeaderModifier": {
+                            "add": [
+                                {
+                                    "name": "Strict-Transport-Security",
+                                    "value": f"max-age={config.hsts_max_age}",
+                                }
+                            ]
+                        },
+                    }
+                ]
+            rules = [rule]
 
         spec: dict = {
             "parentRefs": parent_refs,
@@ -332,6 +349,7 @@ def create_http_routes(
     paths: list[str],
     backend_service_name: str,
     backend_service_port: int,
+    hsts_max_age: int | None = None,
 ) -> None:
     """Create HTTPRoute K8s resources based on https_mode.
 
@@ -345,6 +363,10 @@ def create_http_routes(
         paths: List of path prefixes.
         backend_service_name: Name of the K8s Service to route traffic to.
         backend_service_port: Port of the backend Service.
+        hsts_max_age: ``max-age`` value for the ``Strict-Transport-Security`` header
+            injected on HTTPS routes. Provided by the gateway-api-integrator only
+            when HTTPS is enforced. ``None`` means no HSTS header. ``0`` instructs
+            browsers to clear any cached HSTS policy.
 
     Raises:
         InvalidKubernetesPermissionError: When the charm lacks RBAC permissions.
@@ -390,6 +412,7 @@ def create_http_routes(
                 backend_service_name=backend_service_name,
                 backend_service_port=backend_service_port,
                 redirect_https=False,
+                hsts_max_age=hsts_max_age,
             )
             managed_names.append(http_route_manager.apply(https_config))
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -34,11 +34,14 @@ APP_NAME = "ingress-configurator"
 # Gateway-route (Kubernetes Gateway API) test configuration.
 GATEWAY_API_INTEGRATOR_APP_NAME = "gateway-api-integrator"
 GATEWAY_API_INTEGRATOR_CHANNEL = "1/edge"
-GATEWAY_API_INTEGRATOR_REVISION = 163
+GATEWAY_API_INTEGRATOR_REVISION = 172
 # GatewayClass provided by the Canonical Kubernetes used in CI.
 GATEWAY_CLASS = "ck-gateway"
 EXTERNAL_HOSTNAME = "gateway.internal"
 GATEWAY_CERTIFICATES_CHANNEL = "1/edge"
+# max-age (seconds) for the Strict-Transport-Security header the provider publishes when
+# HTTPS is enforced; a non-default value so the enforced-HTTPS test verifies it flows through.
+GATEWAY_HSTS_MAX_AGE = 15552000
 
 # Closed-ports backend (flask-k8s, is_port_open=False).
 # Also reused by the enforced-HTTPS test, which runs in a separate model.

--- a/tests/integration/test_gateway_route_https.py
+++ b/tests/integration/test_gateway_route_https.py
@@ -33,6 +33,7 @@ from .conftest import (
     GATEWAY_CERTIFICATES_CHANNEL,
     GATEWAY_CONFIGURATOR_CLOSED_PORTS,
     GATEWAY_CONFIGURATOR_OPEN_PORTS,
+    GATEWAY_HSTS_MAX_AGE,
     HOSTNAME_BACKEND_CLOSED_PORTS,
     HOSTNAME_BACKEND_OPEN_PORTS,
     deploy_ingress_configurator_for_gateway_route,
@@ -62,9 +63,9 @@ def multi_relation_https_stack_fixture(
 ) -> HTTPSGatewayStack:
     """Deploy two ingress-configurators on one HTTPS gateway and wait for all Active.
 
-    Enables ``enforce-https`` on the shared gateway, relates it to a TLS provider, then
-    deploys one configurator per backend (closed-ports and open-ports) and wires their
-    ``ingress`` relations.
+    Enables ``enforce-https`` on the shared gateway (with an explicit ``hsts-max-age``), relates
+    it to a TLS provider, then deploys one configurator per backend (closed-ports and
+    open-ports) and wires their ``ingress`` relations.
 
     Args:
         juju_k8s: Jubilant Juju instance for the Kubernetes model.
@@ -76,7 +77,10 @@ def multi_relation_https_stack_fixture(
     Returns:
         Named tuple with all deployed app names.
     """
-    juju_k8s.config(gateway_api_integrator, {"enforce-https": True})
+    juju_k8s.config(
+        gateway_api_integrator,
+        {"enforce-https": True, "hsts-max-age": GATEWAY_HSTS_MAX_AGE},
+    )
     juju_k8s.deploy(charm=CERTIFICATES_APP_NAME, channel=GATEWAY_CERTIFICATES_CHANNEL)
     juju_k8s.integrate(
         f"{CERTIFICATES_APP_NAME}:certificates", f"{gateway_api_integrator}:certificates"
@@ -131,7 +135,8 @@ def test_gateway_route_https_enforced_multi_relation(
     old design (all certs on one hostname-less listener), Envoy NACKs the whole listener and
     both :80 and :443 become unreachable.  With the fix (one listener per hostname, each
     carrying its own ``hostname`` field), Envoy can distinguish chains by SNI and the gateway
-    remains reachable.
+    remains reachable.  It also asserts that each enforced-HTTPS response carries the
+    ``Strict-Transport-Security`` header the requirer injects from the provider's HSTS policy.
 
     Args:
         juju_k8s: Jubilant Juju instance for the Kubernetes model.
@@ -161,10 +166,18 @@ def test_gateway_route_https_enforced_multi_relation(
         )
 
         # HTTPS must reach the backend (SNI carries the hostname; self-signed cert not verified).
-        assert_gateway_response(
+        https_response = assert_gateway_response(
             gateway_address,
             hostname,
             "/",
             scheme="https",
             expected_status=200,
+        )
+
+        # Enforced HTTPS must carry the HSTS header the requirer injects via the
+        # ResponseHeaderModifier filter on the HTTPS HTTPRoute, using the max-age the
+        # provider published from its hsts-max-age config.
+        hsts_header = https_response.headers.get("Strict-Transport-Security")
+        assert hsts_header == f"max-age={GATEWAY_HSTS_MAX_AGE}", (
+            f"expected HSTS header for {hostname}, got {hsts_header!r}"
         )

--- a/tests/unit/test_gateway_route.py
+++ b/tests/unit/test_gateway_route.py
@@ -298,8 +298,8 @@ def test_gateway_route_https_mode_enforced(
     https_rule = https_resource.spec["rules"][0]
     assert https_rule["backendRefs"][0]["port"] == 8080
     hsts_filter = next(f for f in https_rule["filters"] if f["type"] == "ResponseHeaderModifier")
-    assert hsts_filter["responseHeaderModifier"]["add"][0]["name"] == "Strict-Transport-Security"
-    assert hsts_filter["responseHeaderModifier"]["add"][0]["value"] == "max-age=31536000"
+    assert hsts_filter["responseHeaderModifier"]["set"][0]["name"] == "Strict-Transport-Security"
+    assert hsts_filter["responseHeaderModifier"]["set"][0]["value"] == "max-age=31536000"
 
 
 @pytest.mark.usefixtures("mock_lightkube")

--- a/tests/unit/test_gateway_route.py
+++ b/tests/unit/test_gateway_route.py
@@ -249,9 +249,10 @@ def test_gateway_route_https_mode_enforced(
     context_k8s: ops.testing.Context["IngressConfiguratorCharm"], mock_lightkube: "LightkubeClient"
 ):
     """
-    arrange: provider publishes https_mode="enforced".
+    arrange: provider publishes https_mode="enforced" with an hsts_max_age.
     act: trigger config-changed.
-    assert: two HTTPRoute apply calls — HTTP route with 301 redirect, HTTPS route with backendRef.
+    assert: two HTTPRoute apply calls — HTTP route with 301 redirect, HTTPS route with backendRef
+        and a Strict-Transport-Security response header filter.
     """
     state = ops.testing.State(
         config={"hostname": "example.com"},
@@ -267,6 +268,7 @@ def test_gateway_route_https_mode_enforced(
                     "gateway_name": '"my-gateway"',
                     "gateway_model": '"gateway-model"',
                     "https_mode": '"enforced"',
+                    "hsts_max_age": "31536000",
                     "endpoints": json.dumps([]),
                 },
             ),
@@ -295,7 +297,9 @@ def test_gateway_route_https_mode_enforced(
     assert https_resource.spec["parentRefs"][0]["sectionName"] == "my-gateway-https-example-com"
     https_rule = https_resource.spec["rules"][0]
     assert https_rule["backendRefs"][0]["port"] == 8080
-    assert "filters" not in https_rule
+    hsts_filter = next(f for f in https_rule["filters"] if f["type"] == "ResponseHeaderModifier")
+    assert hsts_filter["responseHeaderModifier"]["add"][0]["name"] == "Strict-Transport-Security"
+    assert hsts_filter["responseHeaderModifier"]["add"][0]["value"] == "max-age=31536000"
 
 
 @pytest.mark.usefixtures("mock_lightkube")
@@ -379,7 +383,9 @@ def test_gateway_route_https_mode_enabled(
     """
     arrange: provider publishes https_mode="enabled".
     act: trigger config-changed.
-    assert: two HTTPRoute apply calls, both forwarding to backend (no redirect), on their respective listeners.
+    assert: two HTTPRoute apply calls, both forwarding to backend (no redirect), on their
+        respective listeners. No HSTS filter is present because the provider only sends
+        hsts_max_age when HTTPS is enforced.
     """
     state = ops.testing.State(
         config={"hostname": "example.com"},

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -502,7 +502,7 @@ def test_build_spec_https_includes_hsts_filter():
     filters = rule["filters"]
     assert len(filters) == 1
     assert filters[0]["type"] == "ResponseHeaderModifier"
-    added = filters[0]["responseHeaderModifier"]["add"]
+    added = filters[0]["responseHeaderModifier"]["set"]
     assert len(added) == 1
     assert added[0]["name"] == "Strict-Transport-Security"
     assert added[0]["value"] == "max-age=604800"
@@ -521,7 +521,7 @@ def test_build_spec_hsts_max_age_zero_still_injects_filter():
     rule = spec["rules"][0]  # type: ignore[index]
     filters = rule["filters"]
     assert filters[0]["type"] == "ResponseHeaderModifier"
-    added = filters[0]["responseHeaderModifier"]["add"]
+    added = filters[0]["responseHeaderModifier"]["set"]
     assert added[0]["value"] == "max-age=0"
 
 

--- a/tests/unit/test_http_route.py
+++ b/tests/unit/test_http_route.py
@@ -273,6 +273,7 @@ def test_create_http_routes_http_only():
     arrange: https_mode=disabled, two hostnames.
     act: call create_http_routes.
     assert: a single HTTP route covering both hostnames, attaching to both per-hostname HTTP listeners.
+        The HTTP route never gets HSTS (hsts_max_age=None).
     """
     manager, mock = _make_http_route_manager()
 
@@ -292,6 +293,7 @@ def test_create_http_routes_http_only():
     assert len(applied) == 1
     assert applied[0].scheme == "http"
     assert applied[0].redirect_https is False
+    assert applied[0].hsts_max_age is None
     assert set(applied[0].hostnames) == {"a.example.com", "b.example.com"}
     assert set(applied[0].listener_names) == {
         f"{GW_NAME}-http-a-example-com",
@@ -303,7 +305,7 @@ def test_create_http_routes_https_enabled_single_hostname():
     """
     arrange: https_mode=enabled, one hostname.
     act: call create_http_routes.
-    assert: 2 routes created — 1 HTTP (all hostnames, no redirect) + 1 HTTPS (the hostname).
+    assert: 2 routes created — 1 HTTP (no HSTS) + 1 HTTPS (no HSTS, since none was passed).
     """
     manager, mock = _make_http_route_manager()
 
@@ -326,10 +328,12 @@ def test_create_http_routes_https_enabled_single_hostname():
     https_route = next(r for r in applied if r.scheme == "https")
 
     assert http_route.redirect_https is False
+    assert http_route.hsts_max_age is None
     assert http_route.listener_names == [f"{GW_NAME}-http-app-example-com"]
     assert http_route.hostnames == ["app.example.com"]
     assert https_route.listener_names == [f"{GW_NAME}-https-app-example-com"]
     assert https_route.hostnames == ["app.example.com"]
+    assert https_route.hsts_max_age is None
 
 
 def test_create_http_routes_https_enabled_multiple_hostnames():
@@ -382,14 +386,19 @@ def test_create_http_routes_https_enabled_multiple_hostnames():
 
     for r in http_routes + https_routes:
         assert r.redirect_https is False
+    for r in http_routes:
+        assert r.hsts_max_age is None
+    for r in https_routes:
+        assert r.hsts_max_age is None
 
 
 def test_create_http_routes_https_enforced_multiple_hostnames():
     """
-    arrange: https_mode=enforced, two hostnames.
+    arrange: https_mode=enforced, two hostnames, with an hsts_max_age.
     act: call create_http_routes.
-    assert: 3 routes — 1 HTTP redirect (all hostnames) + 2 HTTPS per hostname.
-        The HTTP route has redirect_https=True; HTTPS routes have redirect_https=False.
+    assert: 3 routes — 1 HTTP redirect (all hostnames, no HSTS) + 2 HTTPS per hostname
+        carrying the HSTS max-age. The HTTP route has redirect_https=True; HTTPS routes
+        have redirect_https=False.
     """
     manager, mock = _make_http_route_manager()
     hostnames = ["alpha.example.com", "beta.example.com"]
@@ -404,6 +413,7 @@ def test_create_http_routes_https_enforced_multiple_hostnames():
         PATHS,
         BACKEND_SVC,
         BACKEND_PORT,
+        hsts_max_age=31536000,
     )
 
     applied = mock._applied
@@ -416,10 +426,12 @@ def test_create_http_routes_https_enforced_multiple_hostnames():
     assert len(https_routes) == 2
 
     assert http_routes[0].redirect_https is True
+    assert http_routes[0].hsts_max_age is None
     assert set(http_routes[0].hostnames) == set(hostnames)
 
     for r in https_routes:
         assert r.redirect_https is False
+        assert r.hsts_max_age == 31536000
         assert len(r.hostnames) == 1
 
 
@@ -447,4 +459,99 @@ def test_create_http_routes_empty_hostnames():
     applied = mock._applied
     assert len(applied) == 1
     assert applied[0].scheme == "http"
+    assert applied[0].hsts_max_age is None
     assert applied[0].listener_names == [f"{GW_NAME}-http"]
+
+
+# ---------------------------------------------------------------------------
+# _build_spec HSTS filter tests
+# ---------------------------------------------------------------------------
+
+
+def _base_https_config(**kwargs) -> HTTPRouteConfig:
+    """Return a minimal HTTPS HTTPRouteConfig for _build_spec tests."""
+    defaults = {
+        "app_name": APP_NAME,
+        "scheme": "https",
+        "gateway_name": GW_NAME,
+        "gateway_namespace": GW_MODEL,
+        "listener_names": [f"{GW_NAME}-https-app-example-com"],
+        "hostnames": ["app.example.com"],
+        "paths": PATHS,
+        "backend_service_name": BACKEND_SVC,
+        "backend_service_port": BACKEND_PORT,
+        "redirect_https": False,
+    }
+    defaults.update(kwargs)
+    return HTTPRouteConfig(**defaults)  # type: ignore[arg-type]
+
+
+def test_build_spec_https_includes_hsts_filter():
+    """
+    arrange: an HTTPS HTTPRouteConfig with hsts_max_age=604800.
+    act: call HTTPRouteManager._build_spec().
+    assert: rules[0] contains a ResponseHeaderModifier filter with the correct
+        Strict-Transport-Security value AND still contains backendRefs.
+    """
+    config = _base_https_config(hsts_max_age=604800)
+    spec = HTTPRouteManager._build_spec(config)
+
+    rule = spec["rules"][0]  # type: ignore[index]
+    assert "backendRefs" in rule
+    assert "filters" in rule
+    filters = rule["filters"]
+    assert len(filters) == 1
+    assert filters[0]["type"] == "ResponseHeaderModifier"
+    added = filters[0]["responseHeaderModifier"]["add"]
+    assert len(added) == 1
+    assert added[0]["name"] == "Strict-Transport-Security"
+    assert added[0]["value"] == "max-age=604800"
+
+
+def test_build_spec_hsts_max_age_zero_still_injects_filter():
+    """
+    arrange: an HTTPS HTTPRouteConfig with hsts_max_age=0.
+    act: call HTTPRouteManager._build_spec().
+    assert: the ResponseHeaderModifier filter is present with max-age=0
+        so browsers clear their cached HSTS policy.
+    """
+    config = _base_https_config(hsts_max_age=0)
+    spec = HTTPRouteManager._build_spec(config)
+
+    rule = spec["rules"][0]  # type: ignore[index]
+    filters = rule["filters"]
+    assert filters[0]["type"] == "ResponseHeaderModifier"
+    added = filters[0]["responseHeaderModifier"]["add"]
+    assert added[0]["value"] == "max-age=0"
+
+
+def test_build_spec_redirect_does_not_include_hsts():
+    """
+    arrange: an HTTPRouteConfig with redirect_https=True and hsts_max_age set.
+    act: call HTTPRouteManager._build_spec().
+    assert: only a RequestRedirect filter is present — no ResponseHeaderModifier.
+        (Redirect rules never carry HSTS; the redirect response itself is the reply.)
+    """
+    config = _base_https_config(redirect_https=True, hsts_max_age=604800)
+    spec = HTTPRouteManager._build_spec(config)
+
+    rule = spec["rules"][0]  # type: ignore[index]
+    assert "backendRefs" not in rule
+    filters = rule["filters"]
+    types = [f["type"] for f in filters]
+    assert "RequestRedirect" in types
+    assert "ResponseHeaderModifier" not in types
+
+
+def test_build_spec_no_hsts_when_hsts_max_age_is_none():
+    """
+    arrange: an HTTPS HTTPRouteConfig with hsts_max_age=None.
+    act: call HTTPRouteManager._build_spec().
+    assert: no filters key is present in the rule (plain backendRefs only).
+    """
+    config = _base_https_config(hsts_max_age=None)
+    spec = HTTPRouteManager._build_spec(config)
+
+    rule = spec["rules"][0]  # type: ignore[index]
+    assert "backendRefs" in rule
+    assert "filters" not in rule


### PR DESCRIPTION
Applicable spec: <link>

### Overview

<!-- A high level overview of the change -->
Retrieves the `hsts-max-age` value from the `gateway-route` relation data.
Uses the value in during the creation of HttpRoutes when the `https-mode` is enforced.


### Rationale

Setting HSTS is a security best practice.
<!-- The reason the change is needed -->

### Juju Events Changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module Changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library Changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [ ] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
