### PR TITLE
feat: support cache-config relation (ISD-6136)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,32 @@ Gateway API is supported through the `gateway-route` relation.
 - Requires that the backend related through `ingress` has opened its ports.
 - `https` option for `backend-protocol` is not supported.
 
+#### Content-cache (optional)
+
+The `cache-config` relation integrates with [content-cache](https://charmhub.io/content-cache)
+to route haproxy traffic through a caching layer instead of directly to the real backend.
+
+```
+juju integrate ingress-configurator content-cache
+```
+
+When the relation is present:
+
+1. ingress-configurator sends the resolved backend addresses and healthcheck config to content-cache.
+2. content-cache returns its own IP and port as `cache-backends`.
+3. ingress-configurator configures haproxy to use the content-cache address as the backend.
+
+When the relation is removed, haproxy reverts to the original backend addresses.
+
+**Limitations:**
+
+- Only supported with `haproxy-route` (HTTP/HTTPS backends).
+- Not supported with `haproxy-route-tcp` (TCP) or `gateway-route` (gRPC).
+
+**Optional configuration:**
+
+- `proxy-cache-valid`: Cache validity rule sent to content-cache, e.g. `"200 1h"`.
+
 To obtain the full list of configurations, see the official [CharmHub documentation](https://charmhub.io/ingress-configurator).
 
 ## Learn more

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -37,6 +37,9 @@ requires:
   gateway-route:
     interface: gateway-route
     limit: 1
+  cache-config:
+    interface: content-cache-config
+    limit: 1
 
 provides:
   ingress:
@@ -58,6 +61,12 @@ config:
     backend-protocol:
       type: string
       description: The protocol that the backend service speaks. "http" (default) or "https".
+    proxy-cache-valid:
+      type: string
+      description: |
+        Cache validity rule to send to the content-cache, e.g. "200 1h".
+        Only used when the cache-config relation is present.
+        If not set, the content-cache uses its own default.
     external-grpc-port:
       type: int
       description: |

--- a/src/charm.py
+++ b/src/charm.py
@@ -7,10 +7,12 @@
 
 """Charm the service."""
 
+import dataclasses
 import json
 import logging
 import typing
 from functools import cached_property
+from urllib.parse import urlparse
 
 import ops
 from charms.gateway_api_integrator.v1.gateway_route import (
@@ -48,6 +50,7 @@ from kubernetes import (
     ensure_nodeport_service,
     get_kubernetes_data,
 )
+from state.cache_config import CACHE_CONFIG_RELATION_NAME, CacheConfigState
 from state.gateway_route import (
     GatewayRouteState,
     InvalidGatewayRouteStateError,
@@ -99,6 +102,12 @@ class IngressConfiguratorCharm(ops.CharmBase):
         self.framework.observe(self.on[GATEWAY_ROUTE_RELATION].relation_changed, self._reconcile)
         self.framework.observe(self.on[GATEWAY_ROUTE_RELATION].relation_broken, self._reconcile)
         self.framework.observe(self.on[GATEWAY_ROUTE_RELATION].relation_departed, self._reconcile)
+        self.framework.observe(
+            self.on[CACHE_CONFIG_RELATION_NAME].relation_changed, self._reconcile
+        )
+        self.framework.observe(
+            self.on[CACHE_CONFIG_RELATION_NAME].relation_broken, self._reconcile
+        )
         self.framework.observe(self.on.update_status, self._on_update_status)
 
         # Action handlers
@@ -132,6 +141,19 @@ class IngressConfiguratorCharm(ops.CharmBase):
                 "Only one route relation type should exist (haproxy-route, haproxy-route-tcp, or gateway-route)."
             )
             return
+
+        cache_config_related = self.model.get_relation(CACHE_CONFIG_RELATION_NAME) is not None
+        if cache_config_related:
+            if haproxy_route_tcp_related:
+                self.unit.status = ops.WaitingStatus(
+                    "cache-config is not supported for TCP protocol"
+                )
+                return
+            if gateway_route_related:
+                self.unit.status = ops.WaitingStatus(
+                    "cache-config is not supported for gRPC protocol"
+                )
+                return
 
         if gateway_route_related:
             self._reconcile_gateway_route()
@@ -220,6 +242,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
             logger.exception("Invalid backend config: %s", exc)
             self.unit.status = ops.BlockedStatus("Invalid backend configuration")
             return
+        charm_state = self._apply_cache_config(charm_state)
+        if charm_state is None:
+            return
         self._provide_haproxy_route_requirements(charm_state)
 
         if proxied_endpoints := self._haproxy_route.get_proxied_endpoints():
@@ -237,6 +262,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
             logger.exception("Invalid backend config: %s", exc)
             self.unit.status = ops.BlockedStatus("Invalid backend configuration")
             return
+        charm_state = self._apply_cache_config(charm_state)
+        if charm_state is None:
+            return
         self._provide_haproxy_route_requirements(charm_state)
 
         if proxied_endpoints := self._haproxy_route.get_proxied_endpoints():
@@ -251,6 +279,9 @@ class IngressConfiguratorCharm(ops.CharmBase):
         except InvalidHaproxyRouteStateError as exc:
             logger.exception("Invalid haproxy-route config: %s", exc)
             self.unit.status = ops.BlockedStatus("Invalid haproxy-route configuration")
+            return
+        charm_state = self._apply_cache_config(charm_state)
+        if charm_state is None:
             return
         self._provide_haproxy_route_requirements(charm_state)
         self.unit.status = ops.ActiveStatus("Ready")
@@ -287,6 +318,53 @@ class IngressConfiguratorCharm(ops.CharmBase):
         }
         not_none_params = {k: v for k, v in params.items() if v is not None}
         self._haproxy_route.provide_haproxy_route_requirements(**not_none_params)
+
+    def _apply_cache_config(self, state: HaproxyRouteState) -> HaproxyRouteState | None:
+        """Apply cache-config backend substitution if the relation is present.
+
+        Writes the resolved backend URLs into the cache-config relation databag,
+        then reads back the cache-backends from content-cache. If cache-backends
+        are not yet available, sets WaitingStatus and returns None.
+
+        Args:
+            state: The resolved HaproxyRouteState with original backend addresses.
+
+        Returns:
+            A new HaproxyRouteState with backends replaced by content-cache address(es),
+            the original state unchanged if no cache-config relation is present,
+            or None if WaitingStatus was set (caller must stop reconciliation).
+        """
+        rel = self.model.get_relation(CACHE_CONFIG_RELATION_NAME)
+        if rel is None:
+            return state
+
+        # Build backend URLs to send to content-cache
+        backends = [
+            f"{state.backend_protocol}://{addr}:{port}"
+            for addr in state.backend_addresses
+            for port in state.backend_ports
+        ]
+
+        # Write config to relation databag
+        cache_state = CacheConfigState.build(self)
+        rel.data[self.app].update(cache_state.to_relation_data(backends))
+
+        # Read cache-backends from content-cache unit databags
+        cache_backends = CacheConfigState.get_cache_backends(rel)
+        if not cache_backends:
+            self.unit.status = ops.WaitingStatus("Waiting for cache-backends from content-cache")
+            return None
+
+        # Parse cache-backend URLs and substitute into a new immutable state
+        parsed_urls = [urlparse(url) for url in cache_backends]
+        new_addresses = [p.hostname for p in parsed_urls if p.hostname]
+        new_ports = list(dict.fromkeys(p.port for p in parsed_urls if p.port))
+        return dataclasses.replace(
+            state,
+            backend_addresses=new_addresses,
+            backend_ports=new_ports,
+            backend_protocol="http",
+        )
 
     def _reconcile_gateway_route(self) -> None:
         """Reconcile gateway-route: create HTTPRoute resources and update relation data.

--- a/src/charm.py
+++ b/src/charm.py
@@ -345,9 +345,10 @@ class IngressConfiguratorCharm(ops.CharmBase):
             for port in state.backend_ports
         ]
 
-        # Write config to relation databag
-        cache_state = CacheConfigState.build(self)
-        rel.data[self.app].update(cache_state.to_relation_data(backends))
+        # Only the leader may write to the app databag.
+        if self.unit.is_leader():
+            cache_state = CacheConfigState.build(self)
+            rel.data[self.app].update(cache_state.to_relation_data(backends))
 
         # Read cache-backends from content-cache unit databags
         cache_backends = CacheConfigState.get_cache_backends(rel)
@@ -359,11 +360,17 @@ class IngressConfiguratorCharm(ops.CharmBase):
         parsed_urls = [urlparse(url) for url in cache_backends]
         new_addresses = [p.hostname for p in parsed_urls if p.hostname]
         new_ports = list(dict.fromkeys(p.port for p in parsed_urls if p.port))
+        if not new_addresses or not new_ports:
+            self.unit.status = ops.WaitingStatus(
+                "Invalid cache-backends received from content-cache"
+            )
+            return None
+        backend_protocol = parsed_urls[0].scheme or "http"
         return dataclasses.replace(
             state,
             backend_addresses=new_addresses,
             backend_ports=new_ports,
-            backend_protocol="http",
+            backend_protocol=backend_protocol,
         )
 
     def _reconcile_gateway_route(self) -> None:

--- a/src/state/cache_config.py
+++ b/src/state/cache_config.py
@@ -81,5 +81,14 @@ class CacheConfigState:
         for unit in rel.units:
             raw = rel.data[unit].get("cache-backends", "")
             if raw:
-                all_backends.extend(json.loads(raw))
+                try:
+                    parsed = json.loads(raw)
+                    if isinstance(parsed, list):
+                        all_backends.extend(parsed)
+                    else:
+                        logger.warning(
+                            "Unexpected cache-backends format from %s: %r", unit.name, raw
+                        )
+                except json.JSONDecodeError:
+                    logger.warning("Malformed cache-backends JSON from %s: %r", unit.name, raw)
         return all_backends if all_backends else None

--- a/src/state/cache_config.py
+++ b/src/state/cache_config.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Cache-config relation state management module."""
+
+import json
+import logging
+from typing import Optional, Self, cast
+
+import ops
+from pydantic.dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+CACHE_CONFIG_RELATION_NAME = "cache-config"
+
+
+@dataclass(frozen=True)
+class CacheConfigState:
+    """State for the cache-config relation.
+
+    Attributes:
+        proxy_cache_valid: Cache validity rule, e.g. "200 1h". None means not configured.
+        healthcheck_interval: Health check interval in seconds, from charm config.
+        healthcheck_path: Health check path, from charm config.
+    """
+
+    proxy_cache_valid: Optional[str]
+    healthcheck_interval: Optional[int]
+    healthcheck_path: Optional[str]
+
+    @classmethod
+    def build(cls, charm: ops.CharmBase) -> Self:
+        """Build CacheConfigState from charm config.
+
+        Args:
+            charm: The ingress-configurator charm instance.
+
+        Returns:
+            CacheConfigState populated from charm config.
+        """
+        return cls(
+            proxy_cache_valid=cast(Optional[str], charm.config.get("proxy-cache-valid")),
+            healthcheck_interval=cast(Optional[int], charm.config.get("health-check-interval")),
+            healthcheck_path=cast(Optional[str], charm.config.get("health-check-path")),
+        )
+
+    def to_relation_data(self, backends: list[str]) -> dict[str, str]:
+        """Build the dict to write into the requirer app databag.
+
+        Args:
+            backends: List of backend URLs, e.g. ["http://10.0.0.1:8080"].
+
+        Returns:
+            Dict of string key/value pairs to write to the relation databag.
+        """
+        data: dict[str, str] = {
+            "backends": json.dumps(backends),
+            "healthcheck_interval": str((self.healthcheck_interval or 10) * 1000),
+            "healthcheck_path": self.healthcheck_path or "/",
+            "healthcheck_valid_status": json.dumps([200]),
+        }
+        if self.proxy_cache_valid is not None:
+            data["proxy_cache_valid"] = json.dumps([self.proxy_cache_valid])
+        return data
+
+    @staticmethod
+    def get_cache_backends(rel: ops.Relation) -> list[str] | None:
+        """Read cache-backends from all content-cache unit databags.
+
+        content-cache writes cache-backends as a JSON list to its own unit databag.
+        An empty string sentinel means the relation was cleared.
+
+        Args:
+            rel: The cache-config relation.
+
+        Returns:
+            List of cache-backend URLs if available, None otherwise.
+        """
+        all_backends: list[str] = []
+        for unit in rel.units:
+            raw = rel.data[unit].get("cache-backends", "")
+            if raw:
+                all_backends.extend(json.loads(raw))
+        return all_backends if all_backends else None

--- a/tests/unit/state/test_cache_config.py
+++ b/tests/unit/state/test_cache_config.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Unit tests for CacheConfigState."""
+
+import json
+from unittest.mock import MagicMock
+
+import ops
+import pytest
+
+from state.cache_config import CacheConfigState
+
+
+def _make_charm(config: dict) -> MagicMock:
+    charm = MagicMock(spec=ops.CharmBase)
+    charm.config = config
+    return charm
+
+
+def test_build_with_no_config():
+    """
+    arrange: charm with no cache-related config set.
+    act: build CacheConfigState.
+    assert: all optional fields are None.
+    """
+    charm = _make_charm({})
+    state = CacheConfigState.build(charm)
+    assert state.proxy_cache_valid is None
+    assert state.healthcheck_interval is None
+    assert state.healthcheck_path is None
+
+
+def test_build_with_all_config():
+    """
+    arrange: charm with proxy-cache-valid, health-check-interval, health-check-path set.
+    act: build CacheConfigState.
+    assert: fields are populated from config.
+    """
+    charm = _make_charm(
+        {
+            "proxy-cache-valid": "200 1h",
+            "health-check-interval": 5,
+            "health-check-path": "/health",
+        }
+    )
+    state = CacheConfigState.build(charm)
+    assert state.proxy_cache_valid == "200 1h"
+    assert state.healthcheck_interval == 5
+    assert state.healthcheck_path == "/health"
+
+
+def test_to_relation_data_minimal():
+    """
+    arrange: CacheConfigState with no optional fields.
+    act: call to_relation_data with one backend URL.
+    assert: dict contains backends, default healthcheck fields, no proxy_cache_valid.
+    """
+    state = CacheConfigState(
+        proxy_cache_valid=None,
+        healthcheck_interval=None,
+        healthcheck_path=None,
+    )
+    data = state.to_relation_data(["http://10.0.0.1:8080"])
+    assert json.loads(data["backends"]) == ["http://10.0.0.1:8080"]
+    assert data["healthcheck_interval"] == "10000"  # None → 10 * 1000ms
+    assert data["healthcheck_path"] == "/"
+    assert json.loads(data["healthcheck_valid_status"]) == [200]
+    assert "proxy_cache_valid" not in data
+
+
+def test_to_relation_data_with_all_options():
+    """
+    arrange: CacheConfigState with all optional fields set.
+    act: call to_relation_data with multiple backends.
+    assert: dict contains all fields correctly serialised.
+    """
+    state = CacheConfigState(
+        proxy_cache_valid="200 1h",
+        healthcheck_interval=5,
+        healthcheck_path="/health",
+    )
+    data = state.to_relation_data(["http://10.0.0.1:8080", "http://10.0.0.2:8080"])
+    assert json.loads(data["backends"]) == ["http://10.0.0.1:8080", "http://10.0.0.2:8080"]
+    assert data["healthcheck_interval"] == "5000"  # 5s → 5000ms
+    assert data["healthcheck_path"] == "/health"
+    assert json.loads(data["proxy_cache_valid"]) == ["200 1h"]
+
+
+def test_get_cache_backends_returns_none_when_no_units():
+    """
+    arrange: relation with no remote units.
+    act: call get_cache_backends.
+    assert: returns None.
+    """
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = set()
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result is None
+
+
+def test_get_cache_backends_returns_none_when_field_missing():
+    """
+    arrange: relation with one remote unit whose databag has no cache-backends key.
+    act: call get_cache_backends.
+    assert: returns None.
+    """
+    unit = MagicMock(spec=ops.Unit)
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = {unit}
+    rel.data = {unit: {}}
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result is None
+
+
+def test_get_cache_backends_returns_none_when_empty_string():
+    """
+    arrange: content-cache has cleared cache-backends (empty string sentinel).
+    act: call get_cache_backends.
+    assert: returns None (treat cleared as not-available).
+    """
+    unit = MagicMock(spec=ops.Unit)
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = {unit}
+    rel.data = {unit: {"cache-backends": ""}}
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result is None
+
+
+def test_get_cache_backends_returns_none_when_empty_list():
+    """
+    arrange: content-cache wrote an empty JSON list.
+    act: call get_cache_backends.
+    assert: returns None.
+    """
+    unit = MagicMock(spec=ops.Unit)
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = {unit}
+    rel.data = {unit: {"cache-backends": "[]"}}
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result is None
+
+
+def test_get_cache_backends_returns_urls():
+    """
+    arrange: content-cache has written valid cache-backends JSON.
+    act: call get_cache_backends.
+    assert: returns the parsed list of URLs.
+    """
+    unit = MagicMock(spec=ops.Unit)
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = {unit}
+    rel.data = {unit: {"cache-backends": '["http://10.1.0.5:8080"]'}}
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result == ["http://10.1.0.5:8080"]
+
+
+def test_get_cache_backends_aggregates_multiple_units():
+    """
+    arrange: two content-cache units each with one cache-backend URL.
+    act: call get_cache_backends.
+    assert: returns all URLs combined.
+    """
+    unit1 = MagicMock(spec=ops.Unit)
+    unit2 = MagicMock(spec=ops.Unit)
+    rel = MagicMock(spec=ops.Relation)
+    rel.units = {unit1, unit2}
+    rel.data = {
+        unit1: {"cache-backends": '["http://10.1.0.5:8080"]'},
+        unit2: {"cache-backends": '["http://10.1.0.6:8080"]'},
+    }
+    result = CacheConfigState.get_cache_backends(rel)
+    assert result is not None
+    assert sorted(result) == ["http://10.1.0.5:8080", "http://10.1.0.6:8080"]

--- a/tests/unit/state/test_cache_config.py
+++ b/tests/unit/state/test_cache_config.py
@@ -7,7 +7,6 @@ import json
 from unittest.mock import MagicMock
 
 import ops
-import pytest
 
 from state.cache_config import CacheConfigState
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -427,3 +427,152 @@ def test_routes_mutual_exclusivity(
         out.unit_status.message
         == "Only one route relation type should exist (haproxy-route, haproxy-route-tcp, or gateway-route)."
     )
+
+
+# ── cache-config tests ────────────────────────────────────────────────────────
+
+
+def test_cache_config_unsupported_for_tcp(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: haproxy-route-tcp and cache-config relations are both present.
+    act: trigger config-changed.
+    assert: WaitingStatus with TCP message — cache-config does not support TCP.
+    """
+    state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1", "backend-ports": "8080"},
+        relations=[
+            ops.testing.Relation("haproxy-route-tcp"),
+            ops.testing.Relation("cache-config"),
+        ],
+        leader=True,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+    assert out.unit_status == ops.testing.WaitingStatus(
+        "cache-config is not supported for TCP protocol"
+    )
+
+
+def test_cache_config_unsupported_for_gateway_route(
+    context_k8s: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: gateway-route and cache-config relations are both present (Kubernetes).
+    act: trigger config-changed.
+    assert: WaitingStatus with gRPC message.
+    """
+    state = ops.testing.State(
+        relations=[
+            ops.testing.Relation("gateway-route"),
+            ops.testing.Relation("cache-config"),
+        ],
+        leader=True,
+    )
+    out = context_k8s.run(context_k8s.on.config_changed(), state)
+    assert out.unit_status == ops.testing.WaitingStatus(
+        "cache-config is not supported for gRPC protocol"
+    )
+
+
+def test_cache_config_waiting_for_cache_backends(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: cache-config relation present, content-cache has not yet written cache-backends.
+    act: trigger config-changed.
+    assert: WaitingStatus — charm is waiting for cache-backends.
+    """
+    state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1", "backend-ports": "8080"},
+        relations=[
+            ops.testing.Relation("haproxy-route"),
+            ops.testing.Relation("cache-config"),
+        ],
+        leader=True,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+    assert out.unit_status == ops.testing.WaitingStatus(
+        "Waiting for cache-backends from content-cache"
+    )
+
+
+def test_cache_config_replaces_backends_when_available(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: cache-config relation present, content-cache has written cache-backends.
+    act: trigger config-changed.
+    assert: ActiveStatus and haproxy-route backends are the content-cache address, not original.
+    """
+    state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1", "backend-ports": "8080"},
+        relations=[
+            ops.testing.Relation("haproxy-route"),
+            ops.testing.Relation(
+                "cache-config",
+                remote_units_data={0: {"cache-backends": '["http://10.1.0.5:9000"]'}},
+            ),
+        ],
+        leader=True,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+
+    assert out.unit_status == ops.testing.ActiveStatus("Ready")
+    haproxy_data = out.get_relations("haproxy-route")[0].local_app_data
+    assert haproxy_data["hosts"] == '["10.1.0.5"]'
+    assert haproxy_data["ports"] == "[9000]"
+
+
+def test_cache_config_sends_relation_data_to_content_cache(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: cache-config relation present with content-cache backends available.
+    act: trigger config-changed.
+    assert: ingress-configurator wrote backends to the cache-config app databag.
+    """
+    state = ops.testing.State(
+        config={
+            "backend-addresses": "10.0.0.1",
+            "backend-ports": "8080",
+            "proxy-cache-valid": "200 1h",
+        },
+        relations=[
+            ops.testing.Relation("haproxy-route"),
+            ops.testing.Relation(
+                "cache-config",
+                remote_units_data={0: {"cache-backends": '["http://10.1.0.5:9000"]'}},
+            ),
+        ],
+        leader=True,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+
+    cache_config_rel = out.get_relations("cache-config")[0]
+    local_app_data = cache_config_rel.local_app_data
+    assert json.loads(local_app_data["backends"]) == ["http://10.0.0.1:8080"]
+    assert json.loads(local_app_data["proxy_cache_valid"]) == ["200 1h"]
+
+
+def test_cache_config_removed_reverts_to_original_backends(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: no cache-config relation (simulates relation-broken completing).
+    act: trigger config-changed.
+    assert: ActiveStatus and haproxy-route uses the original backend address.
+    """
+    state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1", "backend-ports": "8080"},
+        relations=[
+            ops.testing.Relation("haproxy-route"),
+        ],
+        leader=True,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+
+    assert out.unit_status == ops.testing.ActiveStatus("Ready")
+    haproxy_data = out.get_relations("haproxy-route")[0].local_app_data
+    assert haproxy_data["hosts"] == '["10.0.0.1"]'
+    assert haproxy_data["ports"] == "[8080]"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -519,7 +519,7 @@ def test_cache_config_replaces_backends_when_available(
     out = context_machine.run(context_machine.on.config_changed(), state)
 
     assert out.unit_status == ops.testing.ActiveStatus("Ready")
-    haproxy_data = out.get_relations("haproxy-route")[0].local_app_data
+    haproxy_data: dict = dict(out.get_relations("haproxy-route")[0].local_app_data)
     assert haproxy_data["hosts"] == '["10.1.0.5"]'
     assert haproxy_data["ports"] == "[9000]"
 
@@ -550,7 +550,7 @@ def test_cache_config_sends_relation_data_to_content_cache(
     out = context_machine.run(context_machine.on.config_changed(), state)
 
     cache_config_rel = out.get_relations("cache-config")[0]
-    local_app_data = cache_config_rel.local_app_data
+    local_app_data: dict = dict(cache_config_rel.local_app_data)
     assert json.loads(local_app_data["backends"]) == ["http://10.0.0.1:8080"]
     assert json.loads(local_app_data["proxy_cache_valid"]) == ["200 1h"]
 
@@ -573,6 +573,6 @@ def test_cache_config_removed_reverts_to_original_backends(
     out = context_machine.run(context_machine.on.config_changed(), state)
 
     assert out.unit_status == ops.testing.ActiveStatus("Ready")
-    haproxy_data = out.get_relations("haproxy-route")[0].local_app_data
+    haproxy_data: dict = dict(out.get_relations("haproxy-route")[0].local_app_data)
     assert haproxy_data["hosts"] == '["10.0.0.1"]'
     assert haproxy_data["ports"] == "[8080]"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -429,9 +429,6 @@ def test_routes_mutual_exclusivity(
     )
 
 
-# ── cache-config tests ────────────────────────────────────────────────────────
-
-
 def test_cache_config_unsupported_for_tcp(
     context_machine: ops.testing.Context["IngressConfiguratorCharm"],
 ):
@@ -576,3 +573,31 @@ def test_cache_config_removed_reverts_to_original_backends(
     haproxy_data: dict = dict(out.get_relations("haproxy-route")[0].local_app_data)
     assert haproxy_data["hosts"] == '["10.0.0.1"]'
     assert haproxy_data["ports"] == "[8080]"
+
+
+def test_cache_config_non_leader_does_not_write_app_databag(
+    context_machine: ops.testing.Context["IngressConfiguratorCharm"],
+):
+    """
+    arrange: cache-config relation present with cache-backends available, leader=False.
+    act: trigger config-changed.
+    assert: charm does not crash; cache-config app databag is not written by non-leader.
+    """
+    state = ops.testing.State(
+        config={"backend-addresses": "10.0.0.1", "backend-ports": "8080"},
+        relations=[
+            ops.testing.Relation("haproxy-route"),
+            ops.testing.Relation(
+                "cache-config",
+                remote_units_data={0: {"cache-backends": '["http://10.1.0.5:9000"]'}},
+            ),
+        ],
+        leader=False,
+    )
+    out = context_machine.run(context_machine.on.config_changed(), state)
+
+    # Non-leader still gets WaitingStatus (it read the cache-backends, but haproxy-route
+    # app databag is also leader-only — non-leader reaches ActiveStatus only if the
+    # haproxy-route write is also guarded; here we assert it does not crash).
+    cache_rel = out.get_relations("cache-config")[0]
+    assert dict(cache_rel.local_app_data) == {}, "non-leader must not write app databag"


### PR DESCRIPTION
## Summary

Adds `cache-config` relation support so the ingress-configurator can route haproxy traffic through a content-cache instance instead of directly to the real backend.

## Changes

- **`src/state/cache_config.py`** (new): `CacheConfigState` dataclass — builds relation data to send to content-cache, reads back `cache-backends` from unit databags
- **`charmcraft.yaml`**: `cache-config` requires endpoint (`interface: content-cache-config`) + new `proxy-cache-valid` config option
- **`src/charm.py`**: observers for relation events, protocol guard in `_reconcile`, new `_apply_cache_config()` method, substitution inserted in all three haproxy-route reconcile variants
- **Tests**: 10 unit tests for `CacheConfigState`, 6 charm-level tests covering all scenarios
- **Docs**: README updated with cache-config integration section

## How it works

When `cache-config` is related to content-cache:

1. ingress-configurator resolves backend addresses (from config or ingress relation)
2. Writes backend URLs + healthcheck config to the relation's app databag
3. content-cache returns its own IP/port as `cache-backends` in its unit databag
4. ingress-configurator replaces the haproxy backend with the content-cache address
5. haproxy routes traffic through content-cache → real backend

When the relation is removed, haproxy reverts to the original backend addresses automatically.

## Protocol restrictions

TCP and gRPC protocols are not supported (content-cache is an HTTP reverse proxy):
- `haproxy-route-tcp` + `cache-config` → `WaitingStatus("cache-config is not supported for TCP protocol")`
- `gateway-route` + `cache-config` → `WaitingStatus("cache-config is not supported for gRPC protocol")`

## Integration command

```
juju integrate ingress-configurator content-cache
```

Closes ISD-6136